### PR TITLE
Reacting on errors happening while loading a bag

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -270,7 +270,7 @@ class BagWidget(QWidget):
         #  but apparently the text is hidden when the bounding loading bar is
         #  shown
         #self.progress_bar.setRange(0, 0)
-        self.set_status_text.emit("Loading '%s'" % filename)
+        self.set_status_text.emit("Loading '%s'..." % filename)
         #progress_format = self.progress_bar.format()
         #progress_text_visible = self.progress_bar.isTextVisible()
         #self.progress_bar.setFormat("Loading %s" % filename)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -263,6 +263,10 @@ class BagWidget(QWidget):
         if filename[0] != '':
             self.load_bag(filename[0])
 
+    def _print_cause_of_exception(self, exception):
+        qWarning("Loading failed due to: %s" % exception)
+        self.set_status_text.emit("Loading failed due to: %s" % exception)
+
     def load_bag(self, filename):
         qWarning("Loading %s" % filename)
 
@@ -276,24 +280,32 @@ class BagWidget(QWidget):
         #self.progress_bar.setFormat("Loading %s" % filename)
         #self.progress_bar.setTextVisible(True)
 
-        bag = rosbag.Bag(filename)
-        self.play_button.setEnabled(True)
-        self.thumbs_button.setEnabled(True)
-        self.zoom_in_button.setEnabled(True)
-        self.zoom_out_button.setEnabled(True)
-        self.zoom_all_button.setEnabled(True)
-        self.next_button.setEnabled(True)
-        self.previous_button.setEnabled(True)
-        self.faster_button.setEnabled(True)
-        self.slower_button.setEnabled(True)
-        self.begin_button.setEnabled(True)
-        self.end_button.setEnabled(True)
-        self.save_button.setEnabled(True)
-        self.record_button.setEnabled(False)
-        self._timeline.add_bag(bag)
-        qWarning("Done loading %s" % filename )
-        # put the progress bar back the way it was
-        self.set_status_text.emit("")
+        try:
+            bag = rosbag.Bag(filename)
+            self.play_button.setEnabled(True)
+            self.thumbs_button.setEnabled(True)
+            self.zoom_in_button.setEnabled(True)
+            self.zoom_out_button.setEnabled(True)
+            self.zoom_all_button.setEnabled(True)
+            self.next_button.setEnabled(True)
+            self.previous_button.setEnabled(True)
+            self.faster_button.setEnabled(True)
+            self.slower_button.setEnabled(True)
+            self.begin_button.setEnabled(True)
+            self.end_button.setEnabled(True)
+            self.save_button.setEnabled(True)
+            self.record_button.setEnabled(False)
+            self._timeline.add_bag(bag)
+            qWarning("Done loading %s" % filename )
+            # put the progress bar back the way it was
+            self.set_status_text.emit("")
+        except rosbag.ROSBagException as e:
+            self._print_cause_of_exception(e)
+        except rosbag.ROSBagUnindexedException as e:
+            self._print_cause_of_exception(e)
+        except rosbag.ROSBagFormatException as e:
+            self._print_cause_of_exception(e)
+
         #self.progress_bar.setFormat(progress_format)
         #self.progress_bar.setTextVisible(progress_text_visible) # causes a segfault :(
         #self.progress_bar.setRange(0, 100)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -263,18 +263,14 @@ class BagWidget(QWidget):
         if filename[0] != '':
             self.load_bag(filename[0])
 
-    def _print_cause_of_exception(self, exception):
-        qWarning("Loading failed due to: %s" % exception)
-        self.set_status_text.emit("Loading failed due to: %s" % exception)
-
     def load_bag(self, filename):
-        qWarning("Loading %s" % filename)
+        qInfo("Loading '%s'..." % filename)
 
         # QProgressBar can EITHER: show text or show a bouncing loading bar,
         #  but apparently the text is hidden when the bounding loading bar is
         #  shown
         #self.progress_bar.setRange(0, 0)
-        self.set_status_text.emit("Loading %s" % filename)
+        self.set_status_text.emit("Loading '%s'" % filename)
         #progress_format = self.progress_bar.format()
         #progress_text_visible = self.progress_bar.isTextVisible()
         #self.progress_bar.setFormat("Loading %s" % filename)
@@ -296,15 +292,12 @@ class BagWidget(QWidget):
             self.save_button.setEnabled(True)
             self.record_button.setEnabled(False)
             self._timeline.add_bag(bag)
-            qWarning("Done loading %s" % filename )
+            qInfo("Done loading '%s'" % filename )
             # put the progress bar back the way it was
             self.set_status_text.emit("")
         except rosbag.ROSBagException as e:
-            self._print_cause_of_exception(e)
-        except rosbag.ROSBagUnindexedException as e:
-            self._print_cause_of_exception(e)
-        except rosbag.ROSBagFormatException as e:
-            self._print_cause_of_exception(e)
+            qWarning("Loading '%s' failed due to: %s" % (filename, e))
+            self.set_status_text.emit("Loading '%s' failed due to: %s" % (filename, e))
 
         #self.progress_bar.setFormat(progress_format)
         #self.progress_bar.setTextVisible(progress_text_visible) # causes a segfault :(


### PR DESCRIPTION
The widget uses the functionalities of the Bag class without catching the eventual exceptions that could be raised due to faulty bags.
If this happens the exception was raised up to the terminal where the traceback was printed.
In the GUI on the other hand no indication was of an error was printed and "Loading" would have stayed in the status bar indefinitely.
The added code block outputs the information about the cause of the error to the status bar and the terminal.   