### PR TITLE
Maintain image aspect ratio

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -79,9 +79,8 @@ class ImageView(TopicMessageView):
     def _resizeEvent(self, event):
         # TODO make this smarter. currently there will be no scrollbar even if the
         # timeline extends beyond the viewable area
-        self._scene.setSceneRect(0, 0,
-            self._image_view.size().width() - 2,
-            self._image_view.size().height() - 2)
+        self._scene.setSceneRect(
+            0, 0, self._image_view.size().width() - 2, self._image_view.size().height() - 2)
         self.put_image_into_scene()
 
     def message_viewed(self, bag, msg_details):

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -101,7 +101,6 @@ class ImageView(TopicMessageView):
     # End MessageView implementation
     def put_image_into_scene(self):
         if self._image:
-
             scale_factor = min(
                 float(self._image_view.size().width() - 2) / self._image.size[0],
                 float(self._image_view.size().height() - 2) / self._image.size[1])

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -79,8 +79,9 @@ class ImageView(TopicMessageView):
     def _resizeEvent(self, event):
         # TODO make this smarter. currently there will be no scrollbar even if the
         # timeline extends beyond the viewable area
-        self._scene.setSceneRect(
-            0, 0, self._image_view.size().width() - 2, self._image_view.size().height() - 2)
+        self._scene.setSceneRect(0, 0,
+            self._image_view.size().width() - 2,
+            self._image_view.size().height() - 2)
         self.put_image_into_scene()
 
     def message_viewed(self, bag, msg_details):
@@ -101,8 +102,14 @@ class ImageView(TopicMessageView):
     # End MessageView implementation
     def put_image_into_scene(self):
         if self._image:
+
+            scale_factor = min(
+                float(self._image_view.size().width() - 2) / self._image.size[0],
+                float(self._image_view.size().height() - 2) / self._image.size[1])
             resized_image = self._image.resize(
-                (self._image_view.size().width() - 2, self._image_view.size().height() - 2), self.quality)
+                (int(scale_factor * self._image.size[0]),
+                 int(scale_factor * self._image.size[1])),
+                self.quality)
 
             QtImage = ImageQt(resized_image)
             pixmap = QPixmap.fromImage(QtImage)


### PR DESCRIPTION
This prevents images from being stretched, such as when being viewed in a narrow side panel.