### PR TITLE
Save last directory opened to load a bag file

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -60,7 +60,7 @@ class BagWidget(QWidget):
     Handles all widget callbacks and contains the instance of BagTimeline for storing visualizing bag data
     """
 
-    last_open_dir = ""
+    last_open_dir = os.getcwd()
     set_status_text = Signal(str)
 
     def __init__(self, context, publish_clock):

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -37,7 +37,7 @@ import rospy
 import rospkg
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal, QFileInfo
+from python_qt_binding.QtCore import qDebug, QFileInfo, Qt, qWarning, Signal
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -270,7 +270,7 @@ class BagWidget(QWidget):
     def _handle_load_clicked(self):
         filenames = QFileDialog.getOpenFileNames(
             self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.bag} (*.bag)'))
-        if len(filenames) is not 0 and len(filenames[0]) is not 0:
+        if filenames and filenames[0]:
             self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:
             self.load_bag(filename)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -37,7 +37,7 @@ import rospy
 import rospkg
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal
+from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal, QFileInfo
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 
@@ -60,6 +60,7 @@ class BagWidget(QWidget):
     Handles all widget callbacks and contains the instance of BagTimeline for storing visualizing bag data
     """
 
+    last_open_dir = ""
     set_status_text = Signal(str)
 
     def __init__(self, context, publish_clock):
@@ -268,7 +269,9 @@ class BagWidget(QWidget):
 
     def _handle_load_clicked(self):
         filenames = QFileDialog.getOpenFileNames(
-            self, self.tr('Load from Files'), '.', self.tr('Bag files {.bag} (*.bag)'))
+            self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.bag} (*.bag)'))
+        if len(filenames) is not 0 and len(filenames[0]) is not 0:
+            self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:
             self.load_bag(filename)
 


### PR DESCRIPTION
When loading multiple bag files it's annoying to browse again the directory we were before.
This allows to save and re-use the last directory opened.

The value is not saved in a QSettings file so the value is reset after opening the application again; see https://github.com/ros-visualization/rqt_bag/blob/f8cd6a8d506eb99ad3dbd9172cd214baf3c015ef/rqt_bag/src/rqt_bag/bag.py#L92-L95