### PR TITLE
[WIP] Add clear timeline button

### DIFF
--- a/rqt_bag/resource/bag_widget.ui
+++ b/rqt_bag/resource/bag_widget.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -51,6 +60,16 @@
          <width>16</width>
          <height>16</height>
         </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clear_timeline_button">
+       <property name="toolTip">
+        <string>Clear timeline</string>
+       </property>
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -179,6 +179,17 @@ class BagTimeline(QGraphicsScene):
 
             self._timeline_frame.index_cache_cv.notify()
 
+    def clear(self):
+        """
+        clears all previously loaded bags
+        """
+        # FIXME Wrong
+        self._playhead_positions.clear()
+        self._messages_cvs.clear()
+        self._message_loaders.clear()
+        self._timeline_frame.reset_timeline()
+        del self._bags[:]
+
     def file_size(self):
         with self._bag_lock:
             return sum(b.size for b in self._bags)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -95,6 +95,7 @@ class BagWidget(QWidget):
         self.thumbs_button.setIcon(QIcon.fromTheme('insert-image'))
         self.record_button.setIcon(QIcon.fromTheme('media-record'))
         self.load_button.setIcon(QIcon.fromTheme('document-open'))
+        self.clear_timeline_button.setIcon(QIcon.fromTheme('edit-clear'))
         self.save_button.setIcon(QIcon.fromTheme('document-save'))
 
         self.play_button.clicked[bool].connect(self._handle_play_clicked)
@@ -110,6 +111,7 @@ class BagWidget(QWidget):
         self.end_button.clicked[bool].connect(self._handle_end_clicked)
         self.record_button.clicked[bool].connect(self._handle_record_clicked)
         self.load_button.clicked[bool].connect(self._handle_load_clicked)
+        self.clear_timeline_button.clicked[bool].connect(self._handle_clear_timeline_clicked)
         self.save_button.clicked[bool].connect(self._handle_save_clicked)
         self.graphics_view.mousePressEvent = self._timeline.on_mouse_down
         self.graphics_view.mouseReleaseEvent = self._timeline.on_mouse_up
@@ -264,6 +266,7 @@ class BagWidget(QWidget):
             rospy.loginfo('Recording to %s.' % record_filename)
 
             self.load_button.setEnabled(False)
+            self.load_clear_button.setEnabled(False)
             self._recording = True
             self._timeline.record_bag(record_filename, all_topics, selected_topics)
 
@@ -274,6 +277,24 @@ class BagWidget(QWidget):
             self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:
             self.load_bag(filename)
+
+    def _handle_clear_timeline_clicked(self):
+        self._timeline.clear()
+        self.play_button.setEnabled(False)
+        self.thumbs_button.setEnabled(False)
+        self.zoom_in_button.setEnabled(False)
+        self.zoom_out_button.setEnabled(False)
+        self.zoom_all_button.setEnabled(False)
+        self.next_button.setEnabled(False)
+        self.previous_button.setEnabled(False)
+        self.faster_button.setEnabled(False)
+        self.slower_button.setEnabled(False)
+        self.begin_button.setEnabled(False)
+        self.end_button.setEnabled(False)
+        self.save_button.setEnabled(False)
+        self.record_button.setEnabled(True)
+        self.set_status_text.emit("Timeline cleared")
+        # FIXME Does something else needs to be done?
 
     def load_bag(self, filename):
         qDebug("Loading '%s'..." % filename.encode(errors='replace'))

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -37,7 +37,7 @@ import rospy
 import rospkg
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal
+from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal, QFileInfo
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 
@@ -60,6 +60,7 @@ class BagWidget(QWidget):
     Handles all widget callbacks and contains the instance of BagTimeline for storing visualizing bag data
     """
 
+    last_open_dir = ""
     set_status_text = Signal(str)
 
     def __init__(self, context, publish_clock):
@@ -268,7 +269,9 @@ class BagWidget(QWidget):
 
     def _handle_load_clicked(self):
         filenames = QFileDialog.getOpenFileNames(
-            self, self.tr('Load from Files'), '.', self.tr('Bag files {.bag} (*.bag)'))
+            self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.bag} (*.bag)'))
+        if len(filenames) is not 0 and len(filenames[0]) is not 0:
+            self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:
             self.load_bag(filename)
 


### PR DESCRIPTION
# :warning:  Work in progress :warning: 
Fixes #39 
This pull requests adds a button "Clear timeline" that clears all loaded bags so far so that we can start anew without closing/opening `rqt_bag` application.

---

I need help here, I don't know how to properly clear the timeline so that we can load a new bag like when application just started. The following code needs to be fixed as it is clearly wrong (leads to application crash)

https://github.com/ros-visualization/rqt_bag/blob/35d2753b16fb618096b868b228b1681dddab94fe/rqt_bag/src/rqt_bag/bag_timeline.py#L182-L191