### PR TITLE
Avoid exception caused by removing a plot that is still being drawn.

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -195,8 +195,11 @@ class PlotWidget(QWidget):
             self.resample_data(self.paths_on)
 
     def remove_plot(self, path):
-        self.plot.remove_curve(path)
-        self.paths_on.remove(path)
+        try:
+            self.plot.remove_curve(path)
+            self.paths_on.remove(path)
+        except:
+            rospy.logerr("Error removing " + path + " from plot - likely still being drawn.")
         self.plot.redraw()
 
     def load_data(self):


### PR DESCRIPTION
Avoid following exception, especially an issue for large datasets:

```
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_bag_plugins/plot_view.py", line 503, in handleChanged
    self.parent().parent().parent().remove_plot(path)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_bag_plugins/plot_view.py", line 197, in remove_plot
    self.paths_on.remove(path)
```