### PR TITLE
Use cairocffi as the fallback solution for pycairo

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -40,7 +40,10 @@ import sys
 
 from PIL import Image
 from PIL import ImageOps
-import cairo
+try:
+    import cairo
+except ImportError:
+    import cairocffi as cairo
 
 
 def imgmsg_to_pil(img_msg, rgba=True):


### PR DESCRIPTION
The [`cairocffi`](https://cairocffi.readthedocs.io/en/latest/index.html) is another implementation which is API compatible with `pycairo`, it doesn't contain any C\C++ glue code to `cairo` SDK so it doesn't require C\C++ toolchain to be presented at pip install, and it only requires a binary compatible `cairo` shared library on the system. This configuration is convenient for some platforms such as, Windows, to prepare dependencies. So I proposed to add `cairocffi` as a fallback solution in `image_helper.py`.