### PR TITLE
support 16-bit bayer images

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -63,6 +63,12 @@ def imgmsg_to_pil(img_msg, rgba=True):
                 mode = 'BGR'
             elif img_msg.encoding in ['bayer_rggb8', 'bayer_bggr8', 'bayer_gbrg8', 'bayer_grbg8']:
                 mode = 'L'
+            elif img_msg.encoding in ['bayer_rggb16', 'bayer_bggr16', 'bayer_gbrg16', 'bayer_grbg16']:
+                pil_mode = 'I;16'
+                if img_msg.is_bigendian:
+                    mode='I;16B'
+                else:
+                    mode='I;16L'
             elif img_msg.encoding == 'mono16' or img_msg.encoding == '16UC1':
                 pil_mode = 'F'
                 if img_msg.is_bigendian:
@@ -81,6 +87,8 @@ def imgmsg_to_pil(img_msg, rgba=True):
                 pil_mode, (img_msg.width, img_msg.height), img_msg.data, 'raw', mode, 0, 1)
 
         # 16 bits conversion to 8 bits
+        if pil_mode == 'I;16':
+            pil_img = pil_img.convert('I').point(lambda i: i * (1. / 256.)).convert('L')
         if pil_img.mode == 'F':
             pil_img = pil_img.point(lambda i: i * (1. / 256.)).convert('L')
             pil_img = ImageOps.autocontrast(pil_img)


### PR DESCRIPTION
At least in the same limited sense as 8-bit bayer images, namely that they are displayed as monochrome and scaled to 8 bits.  This may not be the best way to remap these onto 8-bits, but at least it's something and its consistent with what `rqt_bag` already does with mono 16-bit images.

Also, FWIW, I originally tried to duplicate the code under the `mono16` encoding, and I was getting errors from PIL about "unknown raw mode", so I'm concerned that code may be broken.
