### PR TITLE
Fully functioning ROS2 port

### DIFF
--- a/rqt_bag/CMakeLists.txt
+++ b/rqt_bag/CMakeLists.txt
@@ -1,17 +1,23 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_bag)
-find_package(catkin REQUIRED)
-catkin_package()
-catkin_python_setup()
+
+# Load ament and all dependencies required for this package
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME}
+    PACKAGE_DIR src/${PROJECT_NAME})
 
 install(FILES plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
 
-install(DIRECTORY launch resource
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+install(DIRECTORY resource
+  DESTINATION share/${PROJECT_NAME}
 )
 
-catkin_install_python(PROGRAMS scripts/rqt_bag
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(PROGRAMS scripts/rqt_bag
+  DESTINATION lib/${PROJECT_NAME}
 )
+
+ament_package()

--- a/rqt_bag/launch/rqt_bag.launch
+++ b/rqt_bag/launch/rqt_bag.launch
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<launch>
-  <arg name="bag" default="" doc="bag file to load"/>
-  <node name="rqt_bag" pkg="rqt_bag" type="rqt_bag"
-    args="$(arg bag)"/>
-</launch>

--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -15,20 +15,13 @@
   <author>Aaron Blasdel</author>
   <author>Tim Field</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
-  <exec_depend>rosbag</exec_depend>
-  <exec_depend>rosgraph_msgs</exec_depend>
-  <exec_depend>roslib</exec_depend>
-  <exec_depend>rosnode</exec_depend>
-  <exec_depend>rospy</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosbag2_transport</exec_depend>
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <export>
-    <architecture_independent/>
+    <build_type>ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -17,7 +17,8 @@
 
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>rosbag2_transport</exec_depend>
+  <exec_depend>rosbag2_py</exec_depend>
+  <exec_depend>rosbag2_transport_py</exec_depend>
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 

--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>rosbag2_transport</exec_depend>
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
+
   <export>
     <build_type>ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag/resource/bag_widget.ui
+++ b/rqt_bag/resource/bag_widget.ui
@@ -329,7 +329,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Time Stamp of the current playhead</string>
+        <string>Timestamp of the current playhead</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
@@ -354,7 +354,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Date and time of the playhead</string>
+        <string>Date and time of the current playhead</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
@@ -385,7 +385,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Number of Seconds from the beginning of the current playhead</string>
+        <string>Number of seconds from the beginning for the current playhead</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
@@ -403,6 +403,9 @@
      </item>
      <item>
       <widget class="QLabel" name="playspeed_label">
+       <property name="toolTip">
+        <string>Playback speed</string>
+       </property>
        <property name="maximumSize">
         <size>
          <width>80</width>
@@ -425,6 +428,9 @@
      </item>
      <item>
       <widget class="QLabel" name="filesize_label">
+       <property name="toolTip">
+        <string>Bag size</string>
+       </property>
        <property name="maximumSize">
         <size>
          <width>80</width>

--- a/rqt_bag/resource/bag_widget.ui
+++ b/rqt_bag/resource/bag_widget.ui
@@ -324,7 +324,7 @@
       <widget class="QLabel" name="stamp_label">
        <property name="maximumSize">
         <size>
-         <width>125</width>
+         <width>185</width>
          <height>16777215</height>
         </size>
        </property>
@@ -349,7 +349,7 @@
       <widget class="QLabel" name="date_label">
        <property name="maximumSize">
         <size>
-         <width>180</width>
+         <width>185</width>
          <height>16777215</height>
         </size>
        </property>
@@ -380,7 +380,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>110</width>
+         <width>90</width>
          <height>16777215</height>
         </size>
        </property>

--- a/rqt_bag/scripts/rqt_bag
+++ b/rqt_bag/scripts/rqt_bag
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -7,11 +7,12 @@ setup(
     package_dir={'': 'src'},
     packages=['rqt_bag', 'rqt_bag.plugins'],
     data_files=[
-        ('share/' + package_name + '/resource', ['resource/bag_widget.ui']),
-        ('share/' + package_name, ['plugin.xml']),
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml'])
+        ('share/' + package_name + '/resource', ['resource/bag_widget.ui']),
+        ('share/' + package_name, ['plugin.xml']),
+        ('share/' + package_name, ['package.xml']),
+        ('lib/' + package_name, ['scripts/rqt_bag'])
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -1,12 +1,33 @@
-#!/usr/bin/env python
+from setuptools import setup
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-d = generate_distutils_setup(
-    packages=['rqt_bag', 'rqt_bag.plugins'],
+package_name = 'rqt_bag'
+setup(
+    name=package_name,
+    version='0.4.12',
     package_dir={'': 'src'},
-    scripts=['scripts/rqt_bag']
+    packages=['rqt_bag', 'rqt_bag.plugins'],
+    data_files=[
+        ('share/' + package_name + '/resource', ['resource/bag_widget.ui']),
+        ('share/' + package_name, ['plugin.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml'])
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    author='Aaron Blasdel, Tim Field',
+    maintainer='Dirk Thomas, Aaron Blasdel, Austin Hendrix',
+    maintainer_email='dthomas@osrfoundation.org',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description=(
+        'rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.'
+    ),
+    license='BSD',
+    scripts=['scripts/rqt_bag'],
 )
-
-setup(**d)

--- a/rqt_bag/src/rqt_bag/bag.py
+++ b/rqt_bag/src/rqt_bag/bag.py
@@ -47,7 +47,8 @@ class Bag(Plugin):
 
     def __init__(self, context):
         """
-        :param context: plugin context hook to enable adding widgets as a ROS_GUI pane, ''PluginContext''
+        :param context: plugin context hook to enable adding widgets as a ROS_GUI pane,
+            ''PluginContext''
         """
         super(Bag, self).__init__(context)
         self.setObjectName('Bag')

--- a/rqt_bag/src/rqt_bag/bag_helper.py
+++ b/rqt_bag/src/rqt_bag/bag_helper.py
@@ -34,24 +34,28 @@
 Helper functions for bag files and timestamps.
 """
 
+from decimal import Decimal
 import math
 import time
-import rospy
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.time import Time
 
 
 def stamp_to_str(t):
     """
-    Convert a rospy.Time to a human-readable string.
+    Convert a rclpy.time.Time to a human-readable string.
 
     @param t: time to convert
-    @type  t: rospy.Time
+    @type  t: rclpy.time.Time
     """
-    t_sec = t.to_sec()
-    if t < rospy.Time.from_sec(60 * 60 * 24 * 365 * 5):
+    t_sec, t_nsec = t.seconds_nanoseconds()
+    if t_sec < (60 * 60 * 24 * 365 * 5):
         # Display timestamps earlier than 1975 as seconds
         return '%.3fs' % t_sec
     else:
-        return time.strftime('%b %d %Y %H:%M:%S', time.localtime(t_sec)) + '.%03d' % (t.nsecs / 1000000)
+        return time.strftime('%b %d %Y %H:%M:%S', time.localtime(t_sec)) + '.%03d' % (t_nsec * 1e-9)
 
 
 def get_topics(bag):
@@ -61,7 +65,7 @@ def get_topics(bag):
     @return: sorted list of topics
     @rtype:  list of str
     """
-    return sorted(set([c.topic for c in bag._get_connections()]))
+    return sorted(bag.get_topics())
 
 
 def get_start_stamp(bag):
@@ -71,8 +75,9 @@ def get_start_stamp(bag):
     @param bag: bag file
     @type  bag: rosbag.Bag
     @return: earliest timestamp
-    @rtype:  rospy.Time
+    @rtype:  rclpy.time.Time
     """
+    return bag.start_time
     start_stamp = None
     for connection_start_stamp in [index[0].time for index in bag._connection_indexes.values()]:
         if not start_stamp or connection_start_stamp < start_stamp:
@@ -87,8 +92,9 @@ def get_end_stamp(bag):
     @param bag: bag file
     @type  bag: rosbag.Bag
     @return: latest timestamp
-    @rtype:  rospy.Time
+    @rtype:  rclpy.time.Time
     """
+    return bag.start_time + bag.duration
     end_stamp = None
     for connection_end_stamp in [index[-1].time for index in bag._connection_indexes.values()]:
         if not end_stamp or connection_end_stamp > end_stamp:
@@ -107,8 +113,8 @@ def get_topics_by_datatype(bag):
     @rtype:  dict of str to list of str
     """
     topics_by_datatype = {}
-    for c in bag._get_connections():
-        topics_by_datatype.setdefault(c.datatype, []).append(c.topic)
+    for name, topic in bag.topics.items():
+        topics_by_datatype.setdefault(topic['topic_metadata']['type'], []).append(name)
 
     return topics_by_datatype
 
@@ -122,6 +128,10 @@ def get_datatype(bag, topic):
     @return: message typename
     @rtype:  str
     """
+    if topic not in bag.topics:
+        return None
+    return bag.topics[topic]['topic_metadata']['type']
+
     for c in bag._get_connections(topic):
         return c.datatype
 
@@ -136,3 +146,17 @@ def filesize_to_str(size):
     if s > 0:
         return '%s %s' % (s, size_name[i])
     return '0 B'
+
+
+def to_sec(t):
+    """
+    Convert an rclpy.time.Time or rclpy.duration.Duration to a float representing seconds
+
+    @param t:
+    @type  t: rclpy.time.Time or rclpy.duration.Duration:
+    @return: result
+    @rtype:  float
+    """
+    # 1e-9 is not exactly 1e-9 if using floating point, so doing this math with floats is imprecise
+    result = Decimal(t.nanoseconds) * Decimal('1e-9')
+    return float(result)

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -744,9 +744,6 @@ class BagTimeline(QGraphicsScene):
             self._messages_cvs[topic] = threading.Condition()
             self._message_loaders[topic] = MessageLoaderThread(self, topic)
 
-        if self._timeline_frame._stamp_left is None:
-            self.reset_zoom()
-
         # Notify the index caching thread that it has work to do
         with self._timeline_frame.index_cache_cv:
             self._timeline_frame.invalidated_caches.add(topic)
@@ -758,6 +755,10 @@ class BagTimeline(QGraphicsScene):
                     listener.timeline_changed()
                 except Exception as ex:
                     qWarning('Error calling timeline_changed on %s: %s' % (type(listener), str(ex)))
+
+        # Reset the zoom level unconditionally so that when recording and exceeding the bounds of 
+        # the current timeline display, the zoom level is adjusted automatically
+        self.reset_zoom()
 
     # Views / listeners
     def add_view(self, topic, frame):

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -184,7 +184,8 @@ class BagTimeline(QGraphicsScene):
 
     def file_size(self):
         with self._bag_lock:
-            return sum(b.size for b in self._bags)
+            x = sum(b.size() for b in self._bags)
+            return sum(b.size() for b in self._bags)
 
     # TODO Rethink API and if these need to be visible
     def _get_start_stamp(self):

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -704,25 +704,23 @@ class BagTimeline(QGraphicsScene):
 
     def record_bag(self, filename, all=True, topics=[], regex=False, limit=0):
         try:
-            self._recorder = Recorder(
-                filename, bag_lock=self._bag_lock, all=all, topics=topics, regex=regex, limit=limit)
+            print("record_bag: filename: {}".format(filename))
+            self._recorder = Recorder(self._context.node, filename, bag_lock=self._bag_lock,
+                    all=all, topics=topics, regex=regex, limit=limit)
         except Exception as ex:
             qWarning('Error opening bag for recording [%s]: %s' % (filename, str(ex)))
             return
 
         self._recorder.add_listener(self._message_recorded)
-
-        #TODO: MJ: Need to have a bag to add
-        # self.add_bag(self._recorder.bag)
-
+        # TODO(mjeronimo): Need to close bag before the YAML file is written and can then open it with Rosbag2(filename)
+        self.add_bag(self._recorder._bag)
         self._recorder.start()
-
         self.wrap = False
         self._timeline_frame._index_cache_thread.period = 0.1
-
         self.update()
 
     def toggle_recording(self):
+        print("bag_timeline: toggle_recording")
         if self._recorder:
             self._recorder.toggle_paused()
             self.update()

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -269,9 +269,12 @@ class BagTimeline(QGraphicsScene):
                 if bag_end_time is not None and bag_end_time < start_stamp:
                     continue
 
-                # Get all of the entries for the specified topics
+                # Get all of the entries for the specified topics. When opening multiple
+                # bags, the requested topic may not be in a given bag database 
                 for topic in topics:
-                    bag_entries.extend(b._get_entries(start_stamp, end_stamp, topic))
+                    entries = b._get_entries(start_stamp, end_stamp, topic)
+                    if entries is not None:
+                        bag_entries.extend(entries)
 
             for entry in sorted(bag_entries, key=lambda entry: entry.timestamp):
                 yield entry

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -253,22 +253,20 @@ class BagWidget(QWidget):
             return
 
         # TODO Implement limiting by regex and by number of messages per topic
-        self.topic_selection = TopicSelection()
+        self.topic_selection = TopicSelection(self._timeline._context.node)
         self.topic_selection.recordSettingsSelected.connect(self._on_record_settings_selected)
 
     def _on_record_settings_selected(self, all_topics, selected_topics):
-        filename = \
-            QFileDialog.getSaveFileName(self, self.tr('Select prefix for new Bag File'), '.',
-                                        self.tr('Bag files {.bag} (*.bag)'))
-        if filename[0] != '':
-            prefix = filename[0].strip()
+        # Get filename to record to, prepopulating the dialog with a proposed filename
+        proposed_filename = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(time.time()))
+        filename = QFileDialog.getSaveFileName(self, self.tr('Select name for new rosbag'), proposed_filename)
 
-            # Get filename to record to
-            record_filename = time.strftime('%Y-%m-%d-%H-%M-%S.bag', time.localtime(time.time()))
-            if prefix.endswith('.bag'):
-                prefix = prefix[:-len('.bag')]
-            if prefix:
-                record_filename = '%s_%s' % (prefix, record_filename)
+        if filename[0] != '':
+            record_filename = filename[0].strip()
+
+            # TODO: Could remove this or keep in case user enters a .bag extension
+            if record_filename.endswith('.bag'):
+                record_filename = record_filename[:-len('.bag')]
 
             self._logger.info('Recording to %s.' % record_filename)
 
@@ -277,12 +275,18 @@ class BagWidget(QWidget):
             self._timeline.record_bag(record_filename, all_topics, selected_topics)
 
     def _handle_load_clicked(self):
-        filenames = QFileDialog.getOpenFileNames(
-            self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.yaml} (*.yaml)'))
-        if filenames and filenames[0]:
-            self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
-        for filename in filenames[0]:
-            self.load_bag(filename)
+        # Create a dialog explicitly so that we can set options on it. We're currently using a native dialog
+        # which is not able to multi-select directories
+        dialog = QFileDialog(self)
+        dialog.setFileMode(QFileDialog.Directory)
+        dialog.setOption(QFileDialog.ShowDirsOnly, True)
+
+        if dialog.exec():
+            filenames = dialog.selectedFiles()
+            if filenames:
+                self.last_open_dir = filenames[0]
+            for filename in filenames:
+                self.load_bag(filename + "/metadata.yaml")
 
     def load_bag(self, filename):
         qDebug("Loading '%s'..." % filename.encode(errors='replace'))
@@ -299,7 +303,7 @@ class BagWidget(QWidget):
 
         try:
             with open(filename) as f:
-                bag_info = yaml.load(f)
+                bag_info = yaml.load(f, Loader=yaml.SafeLoader)
                 bag = Rosbag2(bag_info['rosbag2_bagfile_information'], filename)
         except Exception as e:
             qWarning("Loading '%s' failed due to: %s" % (filename.encode(errors='replace'), e))
@@ -333,8 +337,7 @@ class BagWidget(QWidget):
 
     def _handle_save_clicked(self):
         filename = \
-            QFileDialog.getSaveFileName(self, self.tr('Save selected region to file...'), '.',
-                                        self.tr('Bag files {.bag} (*.bag)'))
+            QFileDialog.getSaveFileName(self, self.tr('Save selected region...'), '.')
         if filename[0] != '':
             self._timeline.copy_region_to_bag(filename[0])
 

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -248,9 +248,7 @@ class BagWidget(QWidget):
         self._timeline.zoom_in()
 
     def _handle_record_clicked(self):
-        print("handle_record_clicked")
         if self._recording:
-            print("handle_record_clicked: toggle_recording")
             self._timeline.toggle_recording()
             return
 
@@ -383,17 +381,15 @@ class BagWidget(QWidget):
             spd = self._timeline.play_speed
             if spd != 0.0:
                 if spd > 1.0:
-                    spd_str = '>> %.0fx' % spd
+                    spd_str = '%.0fx' % spd
                 elif spd == 1.0:
-                    spd_str = '>'
+                    spd_str = '1x'
                 elif spd > 0.0:
-                    spd_str = '> 1/%.0fx' % (1.0 / spd)
+                    spd_str = '1/%.0fx' % (1.0 / spd)
                 elif spd > -1.0:
-                    spd_str = '< 1/%.0fx' % (1.0 / -spd)
-                elif spd == 1.0:
-                    spd_str = '<'
+                    spd_str = '1/%.0fx' % (1.0 / -spd)
                 else:
-                    spd_str = '<< %.0fx' % -spd
+                    spd_str = '%.0fx' % -spd
                 self.playspeed_label.setText(spd_str)
             else:
                 self.playspeed_label.setText('')

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -360,7 +360,7 @@ class BagWidget(QWidget):
 
             # Raw timestamp
             self.stamp_label.setText(
-                '%.3fs' % bag_helper.to_sec(self._timeline._timeline_frame.playhead))
+                '%.9fs' % bag_helper.to_sec(self._timeline._timeline_frame.playhead))
 
             # Human-readable time
             self.date_label.setText(
@@ -372,7 +372,9 @@ class BagWidget(QWidget):
                                             self._timeline._timeline_frame.start_stamp))
 
             # File size
-            self.filesize_label.setText(bag_helper.filesize_to_str(self._timeline.file_size()))
+            # TODO:
+            #self.filesize_label.setText(bag_helper.filesize_to_str(self._timeline.file_size()))
+            self.filesize_label.setText("<x> MB")
 
             # Play speed
             spd = self._timeline.play_speed

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -33,18 +33,21 @@
 import os
 import time
 
-import rospy
-import rospkg
+
+from ament_index_python import get_resource
+from rclpy import logging
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import qDebug, QFileInfo, Qt, qWarning, Signal
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 
-import rosbag
+from rosbag2_transport import rosbag2_transport_py
 from rqt_bag import bag_helper
 from .bag_timeline import BagTimeline
 from .topic_selection import TopicSelection
+from .rosbag2 import Rosbag2
+import yaml
 
 
 class BagGraphicsView(QGraphicsView):
@@ -56,8 +59,10 @@ class BagGraphicsView(QGraphicsView):
 class BagWidget(QWidget):
 
     """
-    Widget for use with Bag class to display and replay bag files
-    Handles all widget callbacks and contains the instance of BagTimeline for storing visualizing bag data
+    Widget for use with Bag class to display and replay bag files.
+
+    Handles all widget callbacks and contains the instance of BagTimeline for storing visualizing
+    bag data
     """
 
     last_open_dir = os.getcwd()
@@ -65,11 +70,14 @@ class BagWidget(QWidget):
 
     def __init__(self, context, publish_clock):
         """
-        :param context: plugin context hook to enable adding widgets as a ROS_GUI pane, ''PluginContext''
+        :param context: plugin context hook to enable adding widgets as a ROS_GUI pane,
+            ''PluginContext''
         """
         super(BagWidget, self).__init__()
-        rp = rospkg.RosPack()
-        ui_file = os.path.join(rp.get_path('rqt_bag'), 'resource', 'bag_widget.ui')
+        self._node = context.node
+        self._logger = logging.get_logger('rqt_bag.BagWidget')
+        _, package_path = get_resource('packages', 'rqt_bag')
+        ui_file = os.path.join(package_path, 'share', 'rqt_bag', 'resource', 'bag_widget.ui')
         loadUi(ui_file, self, {'BagGraphicsView': BagGraphicsView})
 
         self.setObjectName('BagWidget')
@@ -142,7 +150,8 @@ class BagWidget(QWidget):
 
     def graphics_view_on_key_press(self, event):
         key = event.key()
-        if key in (Qt.Key_Left, Qt.Key_Right, Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown):
+        if key in (
+                Qt.Key_Left, Qt.Key_Right, Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown):
             # This causes the graphics view to ignore these keys so they can be caught
             # by the bag_widget keyPressEvent
             event.ignore()
@@ -248,9 +257,9 @@ class BagWidget(QWidget):
         self.topic_selection.recordSettingsSelected.connect(self._on_record_settings_selected)
 
     def _on_record_settings_selected(self, all_topics, selected_topics):
-        # TODO verify master is still running
-        filename = QFileDialog.getSaveFileName(
-            self, self.tr('Select prefix for new Bag File'), '.', self.tr('Bag files {.bag} (*.bag)'))
+        filename = \
+            QFileDialog.getSaveFileName(self, self.tr('Select prefix for new Bag File'), '.',
+                                        self.tr('Bag files {.bag} (*.bag)'))
         if filename[0] != '':
             prefix = filename[0].strip()
 
@@ -261,7 +270,7 @@ class BagWidget(QWidget):
             if prefix:
                 record_filename = '%s_%s' % (prefix, record_filename)
 
-            rospy.loginfo('Recording to %s.' % record_filename)
+            self._logger.info('Recording to %s.' % record_filename)
 
             self.load_button.setEnabled(False)
             self._recording = True
@@ -289,27 +298,33 @@ class BagWidget(QWidget):
         # self.progress_bar.setTextVisible(True)
 
         try:
-            bag = rosbag.Bag(filename)
-            self.play_button.setEnabled(True)
-            self.thumbs_button.setEnabled(True)
-            self.zoom_in_button.setEnabled(True)
-            self.zoom_out_button.setEnabled(True)
-            self.zoom_all_button.setEnabled(True)
-            self.next_button.setEnabled(True)
-            self.previous_button.setEnabled(True)
-            self.faster_button.setEnabled(True)
-            self.slower_button.setEnabled(True)
-            self.begin_button.setEnabled(True)
-            self.end_button.setEnabled(True)
-            self.save_button.setEnabled(True)
-            self.record_button.setEnabled(False)
-            self._timeline.add_bag(bag)
-            qDebug("Done loading '%s'" % filename.encode(errors='replace'))
-            # put the progress bar back the way it was
-            self.set_status_text.emit("")
-        except rosbag.ROSBagException as e:
+            with open(filename) as f:
+                bag_info = yaml.load(f)
+                bag = Rosbag2(bag_info['rosbag2_bagfile_information'], filename)
+        except Exception as e:
             qWarning("Loading '%s' failed due to: %s" % (filename.encode(errors='replace'), e))
             self.set_status_text.emit("Loading '%s' failed due to: %s" % (filename, e))
+            return
+
+        qDebug('Loading bag from metadata file "{}" Succeeded'.format(filename))
+
+        self.play_button.setEnabled(True)
+        self.thumbs_button.setEnabled(True)
+        self.zoom_in_button.setEnabled(True)
+        self.zoom_out_button.setEnabled(True)
+        self.zoom_all_button.setEnabled(True)
+        self.next_button.setEnabled(True)
+        self.previous_button.setEnabled(True)
+        self.faster_button.setEnabled(True)
+        self.slower_button.setEnabled(True)
+        self.begin_button.setEnabled(True)
+        self.end_button.setEnabled(True)
+        self.save_button.setEnabled(True)
+        self.record_button.setEnabled(False)
+        self._timeline.add_bag(bag)
+        qDebug("Done loading '%s'" % filename.encode(errors='replace'))
+        # put the progress bar back the way it was
+        self.set_status_text.emit("")
 
         # self.progress_bar.setFormat(progress_format)
         # self.progress_bar.setTextVisible(progress_text_visible) # causes a segfault :(
@@ -317,8 +332,9 @@ class BagWidget(QWidget):
         # self clear loading filename
 
     def _handle_save_clicked(self):
-        filename = QFileDialog.getSaveFileName(
-            self, self.tr('Save selected region to file...'), '.', self.tr('Bag files {.bag} (*.bag)'))
+        filename = \
+            QFileDialog.getSaveFileName(self, self.tr('Save selected region to file...'), '.',
+                                        self.tr('Bag files {.bag} (*.bag)'))
         if filename[0] != '':
             self._timeline.copy_region_to_bag(filename[0])
 
@@ -330,7 +346,8 @@ class BagWidget(QWidget):
             self.progress_bar.setTextVisible(False)
 
     def _update_status_bar(self):
-        if self._timeline._timeline_frame.playhead is None or self._timeline._timeline_frame.start_stamp is None:
+        if self._timeline._timeline_frame.playhead is None or \
+                self._timeline._timeline_frame.start_stamp is None:
             return
         # TODO Figure out why this function is causing a "RuntimeError: wrapped
         # C/C++ object of %S has been deleted" on close if the playhead is moving
@@ -339,7 +356,8 @@ class BagWidget(QWidget):
             self.progress_bar.setValue(self._timeline.background_progress)
 
             # Raw timestamp
-            self.stamp_label.setText('%.3fs' % self._timeline._timeline_frame.playhead.to_sec())
+            self.stamp_label.setText(
+                '%.3fs' % bag_helper.to_sec(self._timeline._timeline_frame.playhead))
 
             # Human-readable time
             self.date_label.setText(
@@ -347,8 +365,8 @@ class BagWidget(QWidget):
 
             # Elapsed time (in seconds)
             self.seconds_label.setText(
-                '%.3fs' % (
-                    self._timeline._timeline_frame.playhead - self._timeline._timeline_frame.start_stamp).to_sec())
+                '%.3fs' % bag_helper.to_sec(self._timeline._timeline_frame.playhead -
+                                            self._timeline._timeline_frame.start_stamp))
 
             # File size
             self.filesize_label.setText(bag_helper.filesize_to_str(self._timeline.file_size()))
@@ -371,7 +389,7 @@ class BagWidget(QWidget):
                 self.playspeed_label.setText(spd_str)
             else:
                 self.playspeed_label.setText('')
-        except:
+        except Exception as e:
             return
     # Shutdown all members
 

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -289,13 +289,13 @@ class BagWidget(QWidget):
                 self.load_bag(filename + "/metadata.yaml")
 
     def load_bag(self, filename):
-        qDebug("Loading '%s'..." % filename.encode(errors='replace'))
+        qDebug("Loading '%s' ..." % filename.encode(errors='replace'))
 
         # QProgressBar can EITHER: show text or show a bouncing loading bar,
         #  but apparently the text is hidden when the bounding loading bar is
         #  shown
         # self.progress_bar.setRange(0, 0)
-        self.set_status_text.emit("Loading '%s'..." % filename)
+        self.set_status_text.emit("Loading '%s' ..." % os.path.split(filename)[0])
         # progress_format = self.progress_bar.format()
         # progress_text_visible = self.progress_bar.isTextVisible()
         # self.progress_bar.setFormat("Loading %s" % filename)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -275,8 +275,8 @@ class BagWidget(QWidget):
             self._timeline.record_bag(record_filename, all_topics, selected_topics)
 
     def _handle_load_clicked(self):
-        # Create a dialog explicitly so that we can set options on it. We're currently using a native dialog
-        # which is not able to multi-select directories
+        # Create a dialog explicitly so that we can set options on it. We're currently using
+        # a native dialog which is not able to multi-select directories
         dialog = QFileDialog(self)
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly, True)
@@ -325,7 +325,10 @@ class BagWidget(QWidget):
         self.end_button.setEnabled(True)
         self.save_button.setEnabled(True)
         self.record_button.setEnabled(False)
+
+        # Add the newly opened bag to the timeline
         self._timeline.add_bag(bag)
+
         qDebug("Done loading '%s'" % filename.encode(errors='replace'))
         # put the progress bar back the way it was
         self.set_status_text.emit("")

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -278,7 +278,7 @@ class BagWidget(QWidget):
 
     def _handle_load_clicked(self):
         filenames = QFileDialog.getOpenFileNames(
-            self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.bag} (*.bag)'))
+            self, self.tr('Load from Files'), self.last_open_dir, self.tr('Bag files {.yaml} (*.yaml)'))
         if filenames and filenames[0]:
             self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -248,7 +248,9 @@ class BagWidget(QWidget):
         self._timeline.zoom_in()
 
     def _handle_record_clicked(self):
+        print("handle_record_clicked")
         if self._recording:
+            print("handle_record_clicked: toggle_recording")
             self._timeline.toggle_recording()
             return
 

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -376,10 +376,8 @@ class BagWidget(QWidget):
                 '%.3fs' % bag_helper.to_sec(self._timeline._timeline_frame.playhead -
                                             self._timeline._timeline_frame.start_stamp))
 
-            # File size
-            # TODO:
-            #self.filesize_label.setText(bag_helper.filesize_to_str(self._timeline.file_size()))
-            self.filesize_label.setText("<x> MB")
+            # Bag size
+            self.filesize_label.setText(bag_helper.filesize_to_str(self._timeline.file_size()))
 
             # Play speed
             spd = self._timeline.play_speed

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -257,7 +257,7 @@ class BagWidget(QWidget):
         self.topic_selection.recordSettingsSelected.connect(self._on_record_settings_selected)
 
     def _on_record_settings_selected(self, all_topics, selected_topics):
-        # Get filename to record to, prepopulating the dialog with a proposed filename
+        # Get bag name to record to, prepopulating the dialog input with the current time
         proposed_filename = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(time.time()))
         filename = QFileDialog.getSaveFileName(self, self.tr('Select name for new rosbag'), proposed_filename)
 
@@ -339,8 +339,10 @@ class BagWidget(QWidget):
         # self clear loading filename
 
     def _handle_save_clicked(self):
+        # Get the bag name to save to, prepopulating the dialog input with the current time
+        proposed_filename = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(time.time()))
         filename = \
-            QFileDialog.getSaveFileName(self, self.tr('Save selected region...'), '.')
+            QFileDialog.getSaveFileName(self, self.tr('Save selected region...'), proposed_filename)
         if filename[0] != '':
             self._timeline.copy_region_to_bag(filename[0])
 

--- a/rqt_bag/src/rqt_bag/index_cache_thread.py
+++ b/rqt_bag/src/rqt_bag/index_cache_thread.py
@@ -64,7 +64,8 @@ class IndexCacheThread(threading.Thread):
                 updated = False
                 for topic in self.timeline.topics:
                     if topic in self.timeline.invalidated_caches:
-                        updated = (self.timeline._update_index_cache(topic) > 0)
+                        if self.timeline._update_index_cache(topic) > 0:
+                            updated = True
                     if topic_num % update_step == 0 or topic_num == total_topics:
                         new_progress = int(100.0 * (float(topic_num) / total_topics))
                         if new_progress != progress:

--- a/rqt_bag/src/rqt_bag/message_listener_thread.py
+++ b/rqt_bag/src/rqt_bag/message_listener_thread.py
@@ -69,7 +69,8 @@ class MessageListenerThread(threading.Thread):
             # Wait for a new message
             cv = self.timeline._messages_cvs[self.topic]
             with cv:
-                while (self.topic not in self.timeline._messages) or (self.bag_msg_data == self.timeline._messages[self.topic]):
+                while (self.topic not in self.timeline._messages) or \
+                        (self.bag_msg_data == self.timeline._messages[self.topic]):
                     cv.wait()
                     if self._stop_flag:
                         return

--- a/rqt_bag/src/rqt_bag/message_loader_thread.py
+++ b/rqt_bag/src/rqt_bag/message_loader_thread.py
@@ -34,9 +34,9 @@ import threading
 
 
 class MessageLoaderThread(threading.Thread):
-
     """
-    Waits for a new playhead position on the given topic, then loads the message at that position and notifies the view threads.
+    Waits for a new playhead position on the given topic, then loads the message at that position
+    and notifies the view threads.
 
     One thread per topic.  Maintains a cache of recently loaded messages.
     """
@@ -66,7 +66,9 @@ class MessageLoaderThread(threading.Thread):
             # Wait for a new entry
             cv = self.timeline._playhead_positions_cvs[self.topic]
             with cv:
-                while (self.topic not in self.timeline._playhead_positions) or (self.bag_playhead_position == self.timeline._playhead_positions[self.topic]):
+                while (self.topic not in self.timeline._playhead_positions) or \
+                        (self.bag_playhead_position ==
+                            self.timeline._playhead_positions[self.topic]):
                     cv.wait()
                     if self._stop_flag:
                         return

--- a/rqt_bag/src/rqt_bag/node_selection.py
+++ b/rqt_bag/src/rqt_bag/node_selection.py
@@ -78,11 +78,16 @@ class NodeSelection(QWidget):
             self.ok_button.setEnabled(False)
 
     def onButtonClicked(self):
-        #master = rosgraph.Master('rqt_bag_recorder')
-        #state = master.getSystemState()
-        #subs = [t for t, l in state[1]
-        #        if len([node_name for node_name in self.selected_nodes if node_name in l]) > 0]
-        #for topic in subs:
-        #    self.parent_widget.changeTopicCheckState(topic, Qt.Checked)
-        #    self.parent_widget.updateList(Qt.Checked, topic)
+        # Get all of the topics for the selected nodes 
+        topics = set()
+        for node_name in self.selected_nodes:
+            subscription_info_entries = self.node.get_publisher_names_and_types_by_node(node_name, '')
+            for subscription_info in subscription_info_entries:
+                topics.add(subscription_info[0])
+
+        # Select each of these in the (parent) topics dialog
+        for topic in topics:
+            self.parent_widget.changeTopicCheckState(topic, Qt.Checked)
+            self.parent_widget.updateList(Qt.Checked, topic)
+
         self.close()

--- a/rqt_bag/src/rqt_bag/node_selection.py
+++ b/rqt_bag/src/rqt_bag/node_selection.py
@@ -30,17 +30,16 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import rosgraph
-import rosnode
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
 
 
 class NodeSelection(QWidget):
 
-    def __init__(self, parent):
+    def __init__(self, parent, node):
         super(NodeSelection, self).__init__()
         self.parent_widget = parent
+        self.node = node
         self.selected_nodes = []
         self.setWindowTitle("Select the nodes you want to record")
         self.resize(500, 700)
@@ -56,7 +55,7 @@ class NodeSelection(QWidget):
 
         self.selection_vlayout = QVBoxLayout(self)
 
-        self.node_list = rosnode.get_node_names()
+        self.node_list = self.node.get_node_names()
         self.node_list.sort()
         for node in self.node_list:
             self.addCheckBox(node)
@@ -79,11 +78,11 @@ class NodeSelection(QWidget):
             self.ok_button.setEnabled(False)
 
     def onButtonClicked(self):
-        master = rosgraph.Master('rqt_bag_recorder')
-        state = master.getSystemState()
-        subs = [t for t, l in state[1]
-                if len([node_name for node_name in self.selected_nodes if node_name in l]) > 0]
-        for topic in subs:
-            self.parent_widget.changeTopicCheckState(topic, Qt.Checked)
-            self.parent_widget.updateList(Qt.Checked, topic)
+        #master = rosgraph.Master('rqt_bag_recorder')
+        #state = master.getSystemState()
+        #subs = [t for t, l in state[1]
+        #        if len([node_name for node_name in self.selected_nodes if node_name in l]) > 0]
+        #for topic in subs:
+        #    self.parent_widget.changeTopicCheckState(topic, Qt.Checked)
+        #    self.parent_widget.updateList(Qt.Checked, topic)
         self.close()

--- a/rqt_bag/src/rqt_bag/node_selection.py
+++ b/rqt_bag/src/rqt_bag/node_selection.py
@@ -80,6 +80,9 @@ class NodeSelection(QWidget):
     def onButtonClicked(self):
         # Get all of the topics for the selected nodes 
         topics = set()
+
+        # TODO(mjeronimo): handle namespaces
+        # self.selected_nodes should provide both name and namespace
         for node_name in self.selected_nodes:
             subscription_info_entries = self.node.get_publisher_names_and_types_by_node(node_name, '')
             for subscription_info in subscription_info_entries:

--- a/rqt_bag/src/rqt_bag/plugins/message_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/message_view.py
@@ -33,6 +33,8 @@
 
 from python_qt_binding.QtCore import QObject
 
+import rosbag2_py
+
 
 class MessageView(QObject):
 
@@ -47,19 +49,20 @@ class MessageView(QObject):
         self.timeline = timeline
         self.topic = topic
 
-    def message_viewed(self, bag, msg_details):
+    def message_viewed(self, bag, entry, ros_message, msg_type_name, topic):
         """
         View the message.
 
         @param bag: the bag file the message is contained in
         @type  bag: rosbag.Bag
-        @param msg_details: the details of the message to be viewed
-        @type msg_details: tuple (topic, msg, time)
-            @param topic: the message topic
-            @type  topic: str
-            @param msg: the message
-            @param t: the message timestamp
-            @type  t: rospy.Time
+        @param entry: the bag entry of the message to be viewed
+        @type entry: tuple (id, topic_id, timestamp, data)
+        @param ros_message: the (deserialized) ROS message
+        @type msg: ROS message
+        @param msg_type_name: the name of the message type
+        @type string
+        @param topic: the topic on which the message was recorded
+        @type topic: string
         """
         pass
 
@@ -88,9 +91,10 @@ class MessageView(QObject):
         This function will be called to process events posted by post_event
         it will call message_cleared or message_viewed with the relevant data
         """
-        bag, msg_data = event.data
-        if msg_data:
-            self.message_viewed(bag, msg_data)
+        bag, entry = event.data
+        if entry:
+            (ros_message, msg_type_name, topic) = bag.convert_entry_to_ros_message(entry)
+            self.message_viewed(bag, entry, ros_message, msg_type_name, topic)
         else:
             self.message_cleared()
         return True

--- a/rqt_bag/src/rqt_bag/plugins/plugin.py
+++ b/rqt_bag/src/rqt_bag/plugins/plugin.py
@@ -35,7 +35,9 @@ class Plugin(object):
 
     """
     Interface for rqt_bag plugins.
-    User-defined plugins may either subclass `rqt_bag.plugin.Plugin` or according to duck typing implement only the needed methods.
+
+    User-defined plugins may either subclass `rqt_bag.plugin.Plugin` or according to duck typing
+    implement only the needed methods.
     """
 
     def __init__(self):

--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -66,17 +66,16 @@ class RawView(TopicMessageView):
         # This will automatically resize the message_tree to the windowsize
         parent.layout().addWidget(self.message_tree)
 
-    def message_viewed(self, bag, msg_details):
-        super(RawView, self).message_viewed(bag, msg_details)
-        _, _, _, msg = msg_details  # id, topic, timestamp, msg = msg_details
-        if msg is None:
+    def message_viewed(self, bag, entry, ros_message, msg_type_name, topic):
+        super(RawView, self).message_viewed(bag, entry, ros_message, msg_type_name, topic)
+        if ros_message is None:
             self.message_cleared()
         else:
-            self.message_tree.set_message(msg)
+            self.message_tree.set_message(ros_message, msg_type_name)
 
     def message_cleared(self):
         TopicMessageView.message_cleared(self)
-        self.message_tree.set_message(None)
+        self.message_tree.set_message(None, None)
 
 
 class MessageTree(QTreeWidget):
@@ -95,7 +94,7 @@ class MessageTree(QTreeWidget):
     def msg(self):
         return self._msg
 
-    def set_message(self, msg):
+    def set_message(self, msg, msg_type_name):
         """
         Clears the tree view and displays the new message
         :param msg: message object to display in the treeview, ''msg''
@@ -113,7 +112,7 @@ class MessageTree(QTreeWidget):
             # Populate the tree
             # TODO(brawner) msg is stored in the db as a serialized byte array, needs to be
             # unserialized
-            # self._add_msg_object(None, '', '', msg, msg._type)
+            self._add_msg_object(None, '', '', msg, msg_type_name)
 
             if self._expanded_paths is None:
                 self._expanded_paths = set()
@@ -211,7 +210,7 @@ class MessageTree(QTreeWidget):
 
         elif type(obj) in [str, bool, int, long, float, complex, Time]:
             # Ignore any binary data
-            obj_repr = codecs.utf_8_decode(str(obj), 'ignore')[0]
+            obj_repr = str(obj)
 
             # Truncate long representations
             if len(obj_repr) >= 50:
@@ -230,6 +229,9 @@ class MessageTree(QTreeWidget):
         for subobj_name, subobj in subobjs:
             if subobj is None:
                 continue
+
+            # Strip the leading underscore for display
+            subobj_name = subobj_name[1:]
 
             if path == '':
                 subpath = subobj_name  # root field

--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -234,7 +234,8 @@ class MessageTree(QTreeWidget):
                 continue
 
             # Strip the leading underscore for display
-            subobj_name = subobj_name[1:]
+            if subobj_name[0] == '_':
+                subobj_name = subobj_name[1:]
 
             if path == '':
                 subpath = subobj_name  # root field

--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -138,7 +138,8 @@ class MessageTree(QTreeWidget):
                 event.accept()
             elif key == ord('A') or key == ord('a'):
                 # Ctrl-A: select all
-                self._select_all()
+                self.expandAll()
+                self.selectAll()
 
     def _select_all(self):
         for i in self.get_all_items():

--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -83,7 +83,7 @@ class MessageTree(QTreeWidget):
     def __init__(self, parent):
         super(MessageTree, self).__init__(parent)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.setHeaderHidden(True)
+        self.setHeaderHidden(False)
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self._msg = None
 
@@ -99,6 +99,8 @@ class MessageTree(QTreeWidget):
         Clears the tree view and displays the new message
         :param msg: message object to display in the treeview, ''msg''
         """
+        self.setHeaderLabel(msg_type_name)
+
         # Remember whether items were expanded or not before deleting
         if self._msg:
             for item in self.get_all_items():

--- a/rqt_bag/src/rqt_bag/plugins/timeline_renderer.py
+++ b/rqt_bag/src/rqt_bag/plugins/timeline_renderer.py
@@ -38,7 +38,8 @@ class TimelineRenderer(QObject):
     """
     A custom renderer for interval of time of a topic on the timeline.
 
-    @param msg_combine_px: don't draw discrete messages if they're less than this many pixels separated [default: 1.5]
+    @param msg_combine_px: don't draw discrete messages if they're less than this many pixels
+        separated [default: 1.5]
     @type  msg_combine_px: float
     """
 

--- a/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
@@ -33,6 +33,7 @@ from .message_view import MessageView
 
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QAction, QToolBar
+from rclpy.time import Time
 
 
 class TopicMessageView(MessageView):
@@ -78,29 +79,35 @@ class TopicMessageView(MessageView):
 
     # Events
     def navigate_first(self):
-        for entry in self.timeline.get_entries([self.topic], *self.timeline._timeline_frame.play_region):
-            self.timeline._timeline_frame.playhead = entry.time
+        for entry in self.timeline.get_entries(
+                [self.topic], *self.timeline._timeline_frame.play_region):
+            self.timeline._timeline_frame.playhead = Time(nanoseconds=entry.timestamp)
             break
 
     def navigate_previous(self):
         last_entry = None
-        for entry in self.timeline.get_entries([self.topic], self.timeline._timeline_frame.start_stamp, self.timeline._timeline_frame.playhead):
-            if entry.time < self.timeline._timeline_frame.playhead:
+        for entry in self.timeline.get_entries(
+                [self.topic], self.timeline._timeline_frame.start_stamp,
+                self.timeline._timeline_frame.playhead):
+            if Time(nanoseconds=entry.timestamp) < self.timeline._timeline_frame.playhead:
                 last_entry = entry
 
         if last_entry:
-            self.timeline._timeline_frame.playhead = last_entry.time
+            self.timeline._timeline_frame.playhead = Time(nanoseconds=last_entry.timestamp)
 
     def navigate_next(self):
-        for entry in self.timeline.get_entries([self.topic], self.timeline._timeline_frame.playhead, self.timeline._timeline_frame.end_stamp):
-            if entry.time > self.timeline._timeline_frame.playhead:
-                self.timeline._timeline_frame.playhead = entry.time
+        for entry in self.timeline.get_entries(
+                [self.topic], self.timeline._timeline_frame.playhead,
+                self.timeline._timeline_frame.end_stamp):
+            if Time(nanoseconds=entry.timestamp) > self.timeline._timeline_frame.playhead:
+                self.timeline._timeline_frame.playhead = Time(nanoseconds=entry.timestamp)
                 break
 
     def navigate_last(self):
         last_entry = None
-        for entry in self.timeline.get_entries([self.topic], *self.timeline._timeline_frame.play_region):
+        for entry in self.timeline.get_entries(
+                [self.topic], *self.timeline._timeline_frame.play_region):
             last_entry = entry
 
         if last_entry:
-            self.timeline._timeline_frame.playhead = last_entry.time
+            self.timeline._timeline_frame.playhead = Time(nanoseconds=last_entry.timestamp)

--- a/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
@@ -74,8 +74,8 @@ class TopicMessageView(MessageView):
 
     # MessageView implementation
 
-    def message_viewed(self, bag, msg_details):
-        _, _, self._stamp = msg_details[:3]
+    def message_viewed(self, bag, entry, ros_message, msg_type_name, topic):
+        self._stamp = entry.timestamp
 
     # Events
     def navigate_first(self):

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -103,14 +103,11 @@ class Recorder(object):
         self._rosbag_writer = rosbag2_py.SequentialWriter()
         self._rosbag_writer.open(storage_options, converter_options)
 
-        # with open(filename) as f:
-        #     bag_info = yaml.load(f, Loader=yaml.SafeLoader)
-        #     self._bag = Rosbag2(bag_info['rosbag2_bagfile_information'], filename)
-
         # TODO(mjeronimo):
-        # A hack here to create a metadata dictionary (usually read from the one created for the database) sufficient
-        # to create a Rosbag2 object. The rosbag_writer won't create this file until the object is destroyed. Unfortunately,
-        # the writer is kept open so that it can write out messages as they are received.
+        # A hack here to create a metadata dictionary (usually read from the one created for the
+        # database) sufficient to create a Rosbag2 object. The rosbag_writer won't create this file
+        # until the object is destroyed. Unfortunately, the writer is kept open so that it can write
+        # out messages as they are received.
         bag_info = {}
         bag_info['topics_with_message_count'] = []
         for topic, msg_type_names in self.get_topic_names_and_types():
@@ -118,7 +115,8 @@ class Recorder(object):
                 topic_info = {}
                 topic_info['topic_metadata'] = {}
                 topic_info['topic_metadata']['name'] = topic
-                topic_info['topic_metadata']['type'] = msg_type_names[0]    # TODO(mjeronimo): could have multiple type names
+                # TODO(mjeronimo): could have multiple type names
+                topic_info['topic_metadata']['type'] = msg_type_names[0]
                 topic_info['topic_metadata']['serialization_format'] = self._serialization_format
                 topic_info['topic_metadata']['offered_qos_profiles'] = ""
                 bag_info['topics_with_message_count'].append(topic_info)
@@ -173,7 +171,6 @@ class Recorder(object):
         """
         Start subscribing and recording messages to bag.
         """
-        print("Recoder: start")
         self._master_check_thread.start()
         self._write_thread.start()
 
@@ -188,14 +185,12 @@ class Recorder(object):
         self._paused = False
 
     def toggle_paused(self):
-        print("Recorder: toggle_paused")
         self._paused = not self._paused
 
     def stop(self):
         """
         Stop recording.
         """
-        print("Recoder: stop")
         with self._stop_condition:
             self._stop_flag = True
             self._stop_condition.notify_all()
@@ -270,9 +265,7 @@ class Recorder(object):
 
     def _unsubscribe(self, topic):
         try:
-             # TODO(mjeronimo):
-             # self._subscriber_helpers[topic].subscriber.unregister()
-             pass
+             self._node.destroy_subscription(self, self._subscriber_helpers[topic].subscriber)
         except Exception:
             return
 

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -32,6 +32,7 @@
 
 """
 Recorder subscribes to ROS messages and writes them to a bag file.
+TODO (brawner) Port to ROS2. Blocked by missing rclpy rosbag2 interface.
 """
 
 from __future__ import print_function
@@ -43,17 +44,18 @@ import re
 import threading
 import time
 
-import rosbag
-import rosgraph
-import roslib
-import rospy
+#import rosbag
+#import rosgraph
+#import roslib
+#import rospy
 
 import sys
 
 
 class Recorder(object):
 
-    def __init__(self, filename, bag_lock=None, all=True, topics=[], regex=False, limit=0, master_check_interval=1.0):
+    def __init__(self, filename, bag_lock=None, all=True, topics=[], regex=False, limit=0,
+                 master_check_interval=1.0):
         """
         Subscribe to ROS messages and record them to a bag file.
 
@@ -65,9 +67,11 @@ class Recorder(object):
         @type  topics: list of str
         @param regex: topics should be considered as regular expressions [default: False]
         @type  regex: bool
-        @param limit: record only this number of messages on each topic (if non-positive, then unlimited) [default: 0]
+        @param limit: record only this number of messages on each topic (if non-positive, then
+            unlimited) [default: 0]
         @type  limit: int
-        @param master_check_interval: period (in seconds) to check master for new topic publications [default: 1]
+        @param master_check_interval: period (in seconds) to check master for new topic
+            publications [default: 1]
         @type  master_check_interval: float
         """
         self._all = all
@@ -155,7 +159,10 @@ class Recorder(object):
                     #    we've failed to subscribe to it already, or
                     #    we've already reached the message limit, or
                     #    we don't want to subscribe
-                    if topic in self._subscriber_helpers or topic in self._failed_topics or topic in self._limited_topics or not self._should_subscribe_to(topic):
+                    if topic in self._subscriber_helpers or \
+                            topic in self._failed_topics or \
+                            topic in self._limited_topics or \
+                            not self._should_subscribe_to(topic):
                         continue
 
                     try:

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -43,14 +43,10 @@ except ImportError:
 import re
 import threading
 import time
-
-#import rosbag
-#import rosgraph
-#import roslib
-#import rospy
-
 import sys
+import rosbag2_py
 
+from rosbag2_transport import rosbag2_transport_py
 
 class Recorder(object):
 
@@ -80,7 +76,15 @@ class Recorder(object):
         self._limit = limit
         self._master_check_interval = master_check_interval
 
-        self._bag = rosbag.Bag(filename, 'w')
+#       self._bag = rosbag.Bag(filename, 'w')
+#        serialization_format='cdr'
+#        storage_options = rosbag2_py.StorageOptions(uri=filename, storage_id='sqlite3')
+#        converter_options = rosbag2_py.ConverterOptions(
+#            input_serialization_format=serialization_format,
+#            output_serialization_format=serialization_format)
+#        self.rosbag_writer = rosbag2_py.SequentialWriter()
+#        self.rosbag_writer.open(storage_options, converter_options)
+
         self._bag_lock = bag_lock if bag_lock else threading.Lock()
         self._listeners = []
         self._subscriber_helpers = {}
@@ -103,9 +107,9 @@ class Recorder(object):
         self._master_check_thread = threading.Thread(target=self._run_master_check)
         self._write_thread = threading.Thread(target=self._run_write)
 
-    @property
-    def bag(self):
-        return self._bag
+#    @property
+#    def rosbag_writer(self):
+#        return self.rosbag_writer
 
     def add_listener(self, listener):
         """
@@ -148,33 +152,33 @@ class Recorder(object):
     # Implementation
 
     def _run_master_check(self):
-        master = rosgraph.Master('rqt_bag_recorder')
+#        master = rosgraph.Master('rqt_bag_recorder')
 
         try:
             while not self._stop_flag:
                 # Check for new topics
-                for topic, datatype in master.getPublishedTopics(''):
+#                for topic, datatype in master.getPublishedTopics(''):
                     # Check if:
                     #    the topic is already subscribed to, or
                     #    we've failed to subscribe to it already, or
                     #    we've already reached the message limit, or
                     #    we don't want to subscribe
-                    if topic in self._subscriber_helpers or \
-                            topic in self._failed_topics or \
-                            topic in self._limited_topics or \
-                            not self._should_subscribe_to(topic):
-                        continue
+#                    if topic in self._subscriber_helpers or \
+#                            topic in self._failed_topics or \
+#                            topic in self._limited_topics or \
+#                            not self._should_subscribe_to(topic):
+#                        continue
 
-                    try:
-                        pytype = roslib.message.get_message_class(datatype)
+#                    try:
+#                        pytype = roslib.message.get_message_class(datatype)
 
-                        self._message_count[topic] = 0
+#                        self._message_count[topic] = 0
 
-                        self._subscriber_helpers[topic] = _SubscriberHelper(self, topic, pytype)
-                    except Exception as ex:
-                        print('Error subscribing to %s (ignoring): %s' %
-                              (topic, str(ex)), file=sys.stderr)
-                        self._failed_topics.add(topic)
+#                        self._subscriber_helpers[topic] = _SubscriberHelper(self, topic, pytype)
+#                    except Exception as ex:
+#                        print('Error subscribing to %s (ignoring): %s' %
+#                              (topic, str(ex)), file=sys.stderr)
+#                        self._failed_topics.add(topic)
 
                 # Wait a while
                 self._stop_condition.acquire()
@@ -189,7 +193,8 @@ class Recorder(object):
 
         # Close the bag file so that the index gets written
         try:
-            self._bag.close()
+#            self._bag.close()
+             pass
         except Exception as ex:
             print('Error closing bag [%s]: %s' % (self._bag.filename, str(ex)))
 
@@ -208,7 +213,8 @@ class Recorder(object):
 
     def _unsubscribe(self, topic):
         try:
-            self._subscriber_helpers[topic].subscriber.unregister()
+#            self._subscriber_helpers[topic].subscriber.unregister()
+             pass
         except Exception:
             return
 
@@ -235,15 +241,15 @@ class Recorder(object):
                 if item == self:
                     continue
 
-                topic, m, t = item
+#                topic, m, t = item
 
                 # Write to the bag
-                with self._bag_lock:
-                    self._bag.write(topic, m, t)
+#                with self._bag_lock:
+#                    self._bag.write(topic, m, t)
 
                 # Notify listeners that a message has been recorded
-                for listener in self._listeners:
-                    listener(topic, m, t)
+#                for listener in self._listeners:
+#                    listener(topic, m, t)
 
         except Exception as ex:
             print('Error write to bag: %s' % str(ex), file=sys.stderr)
@@ -255,7 +261,7 @@ class _SubscriberHelper(object):
         self.recorder = recorder
         self.topic = topic
 
-        self.subscriber = rospy.Subscriber(self.topic, pytype, self.callback)
+#        self.subscriber = rospy.Subscriber(self.topic, pytype, self.callback)
 
     def callback(self, m):
         self.recorder._record(self.topic, m)

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -56,12 +56,23 @@ class Rosbag2:
             topic['topic_metadata']['name']: topic
             for topic in bag_info['topics_with_message_count']
         }
-        bag_dir = os.path.dirname(filename)
+        self.bag_dir = os.path.dirname(filename)
         database_relative_name = bag_info['relative_file_paths'][0]
-        self.db_name = os.path.join(bag_dir, database_relative_name)
+        self.db_name = os.path.join(self.bag_dir, database_relative_name)
 
         self.start_time = Time(nanoseconds=bag_info['starting_time']['nanoseconds_since_epoch'])
         self.duration = Duration(nanoseconds=bag_info['duration']['nanoseconds'])
+
+    def size(self):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(self.bag_dir):
+            for filename in filenames:
+                full_name = os.path.join(dirpath, filename)
+                # skip if it is symbolic link
+                if not os.path.islink(full_name):
+                    print(os.path.getsize(full_name))
+                    total_size += os.path.getsize(full_name)
+        return total_size
 
     def get_topics(self):
         return list(self.topics.keys())

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -1,0 +1,147 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2019, PickNik Consulting.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This is an example Python interface for rosbag2 to be replaced in the future by a proper
+implementation.
+"""
+
+from collections import namedtuple
+
+from python_qt_binding.QtCore import qDebug
+from rclpy.duration import Duration
+from rclpy.time import Time
+
+import sqlite3
+import os
+
+SQL_COLUMNS = ['id', 'topic_id', 'timestamp', 'data']
+
+
+class Rosbag2:
+    def __init__(self, bag_info, filename):
+        self.filename = filename
+        self.topics = {
+            topic['topic_metadata']['name']: topic
+            for topic in bag_info['topics_with_message_count']
+        }
+        bag_dir = os.path.dirname(filename)
+        database_relative_name = bag_info['relative_file_paths'][0]
+        self.db_name = os.path.join(bag_dir, database_relative_name)
+
+        self.start_time = Time(nanoseconds=bag_info['starting_time']['nanoseconds_since_epoch'])
+        self.duration = Duration(nanoseconds=bag_info['duration']['nanoseconds'])
+
+    def get_topics(self):
+        return list(self.topics.keys())
+
+    def _get_connections(self, topic_name=None):
+        if topic_name is not None:
+            return self.topics(topic_name)
+        return dict(self.topics)
+
+    def close(self):
+        pass
+
+    def get_topic_id(self, topic):
+        db = sqlite3.connect(self.db_name)
+        cursor = db.cursor()
+        search = cursor.execute(
+            'SELECT id FROM topics WHERE name="{}";'.format(topic))
+        entry = search.fetchone()
+        cursor.close()
+        db.close()
+        if entry is None:
+            return None
+        return entry[0]
+
+    def _get_entry(self, timestamp, topic=None):
+        qDebug("Getting entry at {} for topic {}".format(timestamp, topic))
+        db = sqlite3.connect(self.db_name)
+        columns_str = ", ".join(SQL_COLUMNS)
+        cursor = db.cursor()
+        topic_str = ''
+        if topic is not None and topic in self.topics:
+            topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
+        search = cursor.execute(
+            "SELECT {} FROM messages WHERE timestamp<{} {}ORDER BY timestamp DESC LIMIT 1;".format(
+                columns_str, timestamp.nanoseconds, topic_str))
+        entry = search.fetchone()
+        cursor.close()
+        db.close()
+        if entry is None:
+            return None
+
+        Entry = namedtuple('Entry', SQL_COLUMNS)
+        return Entry(*entry)
+
+    def _get_entry_after(self, timestamp, topic=None):
+        qDebug("Getting entry after {} for topic {}".format(timestamp, topic))
+        db = sqlite3.connect(self.db_name)
+
+        columns_str = ", ".join(SQL_COLUMNS)
+        cursor = db.cursor()
+        topic_str = ''
+        if topic is not None and topic in self.topics:
+            topic_str = 'AND topic_id={} '.format(get_topic_id(topic))
+        search = cursor.execute(
+            "SELECT {} FROM messages WHERE timestamp>{} {}LIMIT 1;".format(
+                columns_str, timestamp.nanoseconds, topic_str))
+        entry = search.fetchone()
+        cursor.close()
+        db.close()
+        if entry is None:
+            return None
+
+        Entry = namedtuple('Entry', SQL_COLUMNS)
+        return Entry(*entry)
+
+    def _get_entries(self, t_start, t_end, topic=None):
+        qDebug("Getting entries from {} to {} for topic {}".format(t_start, t_end, topic))
+        db = sqlite3.connect(self.db_name)
+        columns_str = ", ".join(SQL_COLUMNS)
+        cursor = db.cursor()
+        topic_str = ''
+        if topic is not None and topic in self.topics:
+            topic_str = 'AND topic_id={} '.format(get_topic_id(topic))
+        search = cursor.execute(
+            "SELECT {} FROM messages WHERE timestamp>={} AND timestamp <{} {};".format(
+                columns_str, t_start.nanoseconds, t_end.nanoseconds, topic_str))
+        entries = search.fetchall()
+        cursor.close()
+        db.close()
+
+        Entry = namedtuple('Entry', SQL_COLUMNS)
+        return [Entry(*entry) for entry in entries]
+
+    def _read_message(self, position):
+        return self._get_entry(Time(nanoseconds=position))

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -116,8 +116,7 @@ class Rosbag2:
                 return None
             topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
         search = cursor.execute(
-            "SELECT {} FROM messages WHERE timestamp<{} {}ORDER BY timestamp DESC LIMIT 1;".format(
-            #"SELECT {} FROM messages WHERE timestamp={} {}ORDER BY timestamp DESC LIMIT 1;".format(
+            "SELECT {} FROM messages WHERE timestamp<={} {}ORDER BY timestamp DESC LIMIT 1;".format(
                 columns_str, timestamp.nanoseconds, topic_str))
         entry = search.fetchone()
         cursor.close()

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -70,7 +70,6 @@ class Rosbag2:
                 full_name = os.path.join(dirpath, filename)
                 # skip if it is symbolic link
                 if not os.path.islink(full_name):
-                    print(os.path.getsize(full_name))
                     total_size += os.path.getsize(full_name)
         return total_size
 

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -110,7 +110,10 @@ class Rosbag2:
         columns_str = ", ".join(SQL_COLUMNS)
         cursor = db.cursor()
         topic_str = ''
-        if topic is not None and topic in self.topics:
+        if topic is not None:
+            # The requested topic may not be in this database
+            if topic not in self.topics:
+                return None
             topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
         search = cursor.execute(
             "SELECT {} FROM messages WHERE timestamp<{} {}ORDER BY timestamp DESC LIMIT 1;".format(
@@ -132,8 +135,11 @@ class Rosbag2:
         columns_str = ", ".join(SQL_COLUMNS)
         cursor = db.cursor()
         topic_str = ''
-        if topic is not None and topic in self.topics:
-            topic_str = 'AND topic_id={} '.format(get_topic_id(topic))
+        if topic is not None:
+            # The requested topic may not be in this database
+            if topic not in self.topics:
+                return None
+            topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
         search = cursor.execute(
             "SELECT {} FROM messages WHERE timestamp>{} {}LIMIT 1;".format(
                 columns_str, timestamp.nanoseconds, topic_str))
@@ -152,7 +158,10 @@ class Rosbag2:
         columns_str = ", ".join(SQL_COLUMNS)
         cursor = db.cursor()
         topic_str = ''
-        if topic is not None and topic in self.topics:
+        if topic is not None:
+            # The requested topic may not be in this database
+            if topic not in self.topics:
+                return None
             topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
         search = cursor.execute(
             "SELECT {} FROM messages WHERE timestamp>={} AND timestamp <={} {};".format(

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -155,7 +155,7 @@ class Rosbag2:
         if topic is not None and topic in self.topics:
             topic_str = 'AND topic_id={} '.format(self.get_topic_id(topic))
         search = cursor.execute(
-            "SELECT {} FROM messages WHERE timestamp>={} AND timestamp <{} {};".format(
+            "SELECT {} FROM messages WHERE timestamp>={} AND timestamp <={} {};".format(
                 columns_str, t_start.nanoseconds, t_end.nanoseconds, topic_str))
         entries = search.fetchall()
         cursor.close()

--- a/rqt_bag/src/rqt_bag/timeline_cache.py
+++ b/rqt_bag/src/rqt_bag/timeline_cache.py
@@ -39,6 +39,8 @@ except ImportError:
 import threading
 import time
 
+from rqt_bag import bag_helper
+
 
 class TimelineCache(threading.Thread):
 
@@ -96,11 +98,11 @@ class TimelineCache(threading.Thread):
                 self.items[topic] = []
             topic_cache = self.items[topic]
 
-            cache_entry = (t.to_sec(), item)
+            cache_entry = (bag_helper.to_sec(t), item)
             cache_index = bisect.bisect_right(topic_cache, cache_entry)
             topic_cache.insert(cache_index, cache_entry)
 
-            self._update_last_accessed(topic, t.to_sec())
+            self._update_last_accessed(topic, bag_helper.to_sec(t))
 
             self._limit_cache()
 
@@ -109,7 +111,7 @@ class TimelineCache(threading.Thread):
             # Attempt to get a item from the cache that's within time_threshold secs from stamp
             topic_cache = self.items.get(topic)
             if topic_cache:
-                cache_index = max(0, bisect.bisect_right(topic_cache, (stamp, None)) - 1)
+                cache_index = max(0, bisect.bisect_right(topic_cache, (stamp,)) - 1)
 
                 if cache_index <= len(topic_cache) - 1:
                     # Get cache entry before (or at) timestamp, and entry after
@@ -155,7 +157,7 @@ class TimelineCache(threading.Thread):
             if stamp in topic_item_access:
                 last_access = topic_item_access[stamp]
 
-                index = bisect.bisect_left(topic_last_accessed, (last_access, None))
+                index = bisect.bisect_left(topic_last_accessed, (last_access, ))
                 assert(topic_last_accessed[index][1] == stamp)
 
                 del topic_last_accessed[index]
@@ -172,7 +174,7 @@ class TimelineCache(threading.Thread):
                 while len(topic_cache) > self.max_cache_size:
                     lru_stamp = self.last_accessed[topic][0][1]
 
-                    cache_index = bisect.bisect_left(topic_cache, (lru_stamp, None))
+                    cache_index = bisect.bisect_left(topic_cache, (lru_stamp, ))
                     assert(topic_cache[cache_index][0] == lru_stamp)
 
                     del topic_cache[cache_index]

--- a/rqt_bag/src/rqt_bag/timeline_cache.py
+++ b/rqt_bag/src/rqt_bag/timeline_cache.py
@@ -125,9 +125,11 @@ class TimelineCache(threading.Thread):
                         cache_after_dist = abs(cache_after_stamp - stamp)
 
                     if cache_after_stamp and cache_after_dist < cache_before_dist:
-                        cache_dist, cache_stamp, cache_item = cache_after_dist, cache_after_stamp, cache_after_item
+                        cache_dist, cache_stamp, cache_item = \
+                            cache_after_dist, cache_after_stamp, cache_after_item
                     else:
-                        cache_dist, cache_stamp, cache_item = cache_before_dist, cache_before_stamp, cache_before_item
+                        cache_dist, cache_stamp, cache_item = \
+                            cache_before_dist, cache_before_stamp, cache_before_item
 
                     # Check entry is close enough
                     if cache_dist <= time_threshold:

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -147,12 +147,10 @@ class TimelineFrame(QGraphicsItem):
         self._default_pen = QPen(Qt.black)
         self._default_datatype_color = QColor(0, 0, 102, 204)
         self._datatype_colors = {
-            'sensor_msgs/CameraInfo': QColor(0, 0, 77, 204),
-            'sensor_msgs/Image': QColor(0, 77, 77, 204),
-            'sensor_msgs/LaserScan': QColor(153, 0, 0, 204),
-            'pr2_msgs/LaserScannerSignal': QColor(153, 0, 0, 204),
-            'pr2_mechanism_msgs/MechanismState': QColor(0, 153, 0, 204),
-            'tf/tfMessage': QColor(0, 153, 0, 204),
+            'sensor_msgs/msg/CameraInfo': QColor(0, 0, 77, 204),
+            'sensor_msgs/msg/Image': QColor(0, 77, 77, 204),
+            'sensor_msgs/msg/LaserScan': QColor(153, 0, 0, 204),
+            'tf2_msgs/msg/TFMessage': QColor(0, 153, 0, 204),
         }
         # minimum number of pixels allowed between two bag messages before they are combined
         self._default_msg_combine_px = 1.0

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -404,7 +404,7 @@ class TimelineFrame(QGraphicsItem):
 
     def _draw_topic_history(self, painter, topic):
         """
-        Draw boxes corrisponding to message regions on the timeline.
+        Draw boxes corresponding to message regions on the timeline.
         :param painter: allows access to paint functions,''QPainter''
         :param topic: the topic for which message boxes should be drawn, ''str''
         """
@@ -835,7 +835,7 @@ class TimelineFrame(QGraphicsItem):
 
         topic_cache_len = len(topic_cache)
 
-        for entry in self.scene().get_entries(topic, start_time, end_time):
+        for entry in self.scene().get_entries([topic], start_time, end_time):
             topic_cache.append(bag_helper.to_sec(Time(nanoseconds=entry.timestamp)))
 
         if topic in self.invalidated_caches:

--- a/rqt_bag/src/rqt_bag/timeline_menu.py
+++ b/rqt_bag/src/rqt_bag/timeline_menu.py
@@ -30,6 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from python_qt_binding.QtCore import qDebug
 from python_qt_binding.QtWidgets import QVBoxLayout, QMenu, QWidget, QDockWidget
 
 
@@ -86,6 +87,8 @@ class TopicPopupWidget(QWidget):
             # create a new viewer
             self._viewer = self._viewer_type(self._timeline, self, self._topic)
             if not self._is_listening:
+                qDebug('Adding listener to topic {} of type {}'.format(
+                        self._topic, type(self._viewer)))
                 self._timeline.add_listener(self._topic, self._viewer)
                 self._is_listening = True
 
@@ -170,7 +173,9 @@ class TimelinePopupMenu(QMenu):
                 datatype_menu = QMenu(datatype, self)
                 datatype_topics = self._topics_by_type[datatype]
                 viewer_types = self.timeline._timeline_frame.get_viewer_types(datatype)
-                for topic in [t for t in self._topics if t in datatype_topics]:   # use timeline ordering
+
+                # use timeline ordering
+                for topic in [t for t in self._topics if t in datatype_topics]:
                     topic_menu = QMenu(topic, datatype_menu)
                     # View... / datatype / topic / Viewer
                     for viewer_type in viewer_types:
@@ -221,6 +226,7 @@ class TimelinePopupMenu(QMenu):
         :param action: action to execute, ''QAction''
         :raises: when it doesn't recognice the action passed in, ''Exception''
         """
+        qDebug('TimelinePopupMenu process action {}'.format(action))
         if action == self._reset_timeline:
             self.timeline._timeline_frame.reset_timeline()
         elif action == self._play_all:

--- a/rqt_bag/src/rqt_bag/topic_selection.py
+++ b/rqt_bag/src/rqt_bag/topic_selection.py
@@ -30,20 +30,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import rosgraph
-
 from python_qt_binding.QtCore import Qt, Signal
 from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
-from .node_selection import NodeSelection
+#from .node_selection import NodeSelection
 
 
 class TopicSelection(QWidget):
 
     recordSettingsSelected = Signal(bool, list)
 
-    def __init__(self):
+    def __init__(self, node):
         super(TopicSelection, self).__init__()
-        master = rosgraph.Master('rqt_bag_recorder')
+        self._node = node
         self.setWindowTitle("Select the topics you want to record")
         self.resize(500, 700)
 
@@ -70,7 +68,7 @@ class TopicSelection(QWidget):
         self.item_all = QCheckBox("All", self)
         self.item_all.stateChanged.connect(self.updateList)
         self.selection_vlayout.addWidget(self.item_all)
-        topic_data_list = master.getPublishedTopics('')
+        topic_data_list = self._node.get_topics_and_topic_types()
         topic_data_list.sort()
         for topic, datatype in topic_data_list:
             self.addCheckBox(topic)

--- a/rqt_bag/src/rqt_bag/topic_selection.py
+++ b/rqt_bag/src/rqt_bag/topic_selection.py
@@ -32,7 +32,7 @@
 
 from python_qt_binding.QtCore import Qt, Signal
 from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
-#from .node_selection import NodeSelection
+from .node_selection import NodeSelection
 
 
 class TopicSelection(QWidget):
@@ -68,7 +68,7 @@ class TopicSelection(QWidget):
         self.item_all = QCheckBox("All", self)
         self.item_all.stateChanged.connect(self.updateList)
         self.selection_vlayout.addWidget(self.item_all)
-        topic_data_list = self._node.get_topics_and_topic_types()
+        topic_data_list = self._node.get_topic_names_and_types()
         topic_data_list.sort()
         for topic, datatype in topic_data_list:
             self.addCheckBox(topic)
@@ -122,4 +122,4 @@ class TopicSelection(QWidget):
             self.item_all.checkState() == Qt.Checked, self.selected_topics)
 
     def onFromNodesButtonClicked(self):
-        self.node_selection = NodeSelection(self)
+        self.node_selection = NodeSelection(self, self._node)

--- a/rqt_bag_plugins/CMakeLists.txt
+++ b/rqt_bag_plugins/CMakeLists.txt
@@ -1,14 +1,19 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_bag_plugins)
-# Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED)
-catkin_package()
-catkin_python_setup()
+
+# Load ament and all dependencies required for this package
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME}
+    PACKAGE_DIR src/${PROJECT_NAME})
 
 install(FILES plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
 
 install(DIRECTORY resource
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
+
+ament_package()

--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -15,16 +15,11 @@
   <author>Aaron Blasdel</author>
   <author>Tim Field</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-cairo</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-cairo</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-imaging</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pil</exec_depend>
-  <exec_depend>rosbag</exec_depend>
-  <exec_depend>roslib</exec_depend>
-  <exec_depend>rospy</exec_depend>
+  <exec_depend>python3-cairo</exec_depend>
+  <exec_depend>python3-pil</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosbag2</exec_depend>
   <exec_depend>rqt_bag</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
@@ -33,7 +28,7 @@
   <exec_depend>std_msgs</exec_depend>
 
   <export>
-    <architecture_independent/>
+    <build_type>ament_python</build_type>
     <rqt_bag plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_bag_plugins/setup.py
+++ b/rqt_bag_plugins/setup.py
@@ -1,11 +1,32 @@
-#!/usr/bin/env python
+from setuptools import setup
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-d = generate_distutils_setup(
+package_name = 'rqt_bag_plugins'
+setup(
+    name=package_name,
+    version='0.4.12',
+    package_dir={'': 'src'},
     packages=['rqt_bag_plugins'],
-    package_dir={'': 'src'}
+    data_files=[
+        ('share/' + package_name + '/resource', ['resource/plot.ui']),
+        ('share/' + package_name, ['plugin.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml'])
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    author='Aaron Blasdel, Tim Field',
+    maintainer='Dirk Thomas, Aaron Blasdel, Austin Hendrix',
+    maintainer_email='dthomas@osrfoundation.org',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description=(
+        'rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.'
+    ),
+    license='BSD',
 )
-
-setup(**d)

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -46,9 +46,9 @@ except ImportError:
     import cairocffi as cairo
 
 
-def imgmsg_to_pil(img_msg, rgba=True):
+def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
     try:
-        if img_msg._type == 'sensor_msgs/CompressedImage':
+        if msg_type_name == 'sensor_msgs/msg/CompressedImage':
             pil_img = Image.open(StringIO(img_msg.data))
             if pil_img.mode != 'L':
                 pil_img = pil_bgr2rgb(pil_img)
@@ -85,7 +85,7 @@ def imgmsg_to_pil(img_msg, rgba=True):
             else:
                 raise Exception("Unsupported image format: %s" % img_msg.encoding)
             pil_img = Image.frombuffer(
-                pil_mode, (img_msg.width, img_msg.height), img_msg.data, 'raw', mode, 0, 1)
+                pil_mode, (img_msg.width, img_msg.height), img_msg.data.tobytes(), 'raw', mode, 0, 1)
 
         # 16 bits conversion to 8 bits
         if pil_mode == 'I;16':

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -75,6 +75,12 @@ def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
                     mode = 'F;16B'
                 else:
                     mode = 'F;16'
+            elif img_msg.encoding == '32FC1':
+                pil_mode = 'F'
+                if img_msg.is_bigendian:
+                    mode = 'F;32BF'
+                else:
+                    mode = 'F;32F'
             elif img_msg.encoding == 'rgba8':
                 mode = 'BGR'
             elif img_msg.encoding == 'bgra8':
@@ -87,6 +93,7 @@ def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
         # 16 bits conversion to 8 bits
         if pil_mode == 'I;16':
             pil_img = pil_img.convert('I').point(lambda i: i * (1. / 256.)).convert('L')
+
         if pil_img.mode == 'F':
             pil_img = pil_img.point(lambda i: i * (1. / 256.)).convert('L')
             pil_img = ImageOps.autocontrast(pil_img)

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -54,9 +54,8 @@ def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
                 pil_img = pil_bgr2rgb(pil_img)
             pil_mode = 'RGB'
         else:
-            alpha = False
             pil_mode = 'RGB'
-            if img_msg.encoding == 'mono8':
+            if img_msg.encoding in ['mono8', '8UC1' ]:
                 mode = 'L'
             elif img_msg.encoding == 'rgb8':
                 mode = 'RGB'
@@ -78,10 +77,8 @@ def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
                     mode = 'F;16'
             elif img_msg.encoding == 'rgba8':
                 mode = 'BGR'
-                alpha = True
             elif img_msg.encoding == 'bgra8':
                 mode = 'RGB'
-                alpha = True
             else:
                 raise Exception("Unsupported image format: %s" % img_msg.encoding)
             pil_img = Image.frombuffer(

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_plugin.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_plugin.py
@@ -48,4 +48,4 @@ class ImagePlugin(Plugin):
         return ImageTimelineRenderer
 
     def get_message_types(self):
-        return ['sensor_msgs/Image', 'sensor_msgs/CompressedImage']
+        return ['sensor_msgs/msg/Image', 'sensor_msgs/msg/CompressedImage']

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -31,8 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
-import rospy
-
+from rclpy.time import Time
 # HACK workaround for upstream pillow issue python-pillow/Pillow#400
 import sys
 from python_qt_binding import QT_BINDING_MODULES
@@ -79,8 +78,8 @@ class ImageTimelineRenderer(TimelineRenderer):
         draws a stream of images for the topic
         :param painter: painter object, ''QPainter''
         :param topic: topic to draw, ''str''
-        :param stamp_start: stamp to start drawing, ''rospy.Time''
-        :param stamp_end: stamp to end drawing, ''rospy.Time''
+        :param stamp_start: stamp to start drawing, ''rclpy.time.Time''
+        :param stamp_end: stamp to end drawing, ''rclpy.time.Time''
         :param x: x to draw images at, ''int''
         :param y: y to draw images at, ''int''
         :param width: width in pixels of the timeline area, ''int''
@@ -156,7 +155,7 @@ class ImageTimelineRenderer(TimelineRenderer):
         (thumbnail_height,) = thumbnail_details
 
         # Find position of stamp using index
-        t = rospy.Time.from_sec(stamp)
+        t = Time(seconds=stamp)
         bag, entry = self.timeline.scene().get_entry(t, topic)
         if not entry:
             return None, None

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -54,7 +54,7 @@ from python_qt_binding.QtGui import QBrush, QPen, QPixmap
 class ImageTimelineRenderer(TimelineRenderer):
 
     """
-    Draws thumbnails of sensor_msgs/Image or sensor_msgs/CompressedImage in the timeline.
+    Draws thumbnails of sensor_msgs/msg/Image or sensor_msgs/msg/CompressedImage in the timeline.
     """
 
     def __init__(self, timeline, thumbnail_height=160):
@@ -159,16 +159,12 @@ class ImageTimelineRenderer(TimelineRenderer):
         bag, entry = self.timeline.scene().get_entry(t, topic)
         if not entry:
             return None, None
-        pos = entry.position
 
-        # Not in the cache; load from the bag file
-
-        with self.timeline.scene()._bag_lock:
-            msg_topic, msg, msg_stamp = bag._read_message(pos)
+        (ros_message, msg_type, topic) = bag.convert_entry_to_ros_message(entry)
 
         # Convert from ROS image to PIL image
         try:
-            pil_image = image_helper.imgmsg_to_pil(msg)
+            pil_image = image_helper.imgmsg_to_pil(ros_message, msg_type)
         except Exception as ex:
             print('Error loading image on topic %s: %s' % (topic, str(ex)), file=sys.stderr)
             pil_image = None
@@ -186,7 +182,7 @@ class ImageTimelineRenderer(TimelineRenderer):
             # Scale to thumbnail size
             thumbnail = pil_image.resize((thumbnail_width, thumbnail_height), self.quality)
 
-            return msg_stamp, thumbnail
+            return t, thumbnail
 
         except Exception as ex:
             print('Error loading image on topic %s: %s' % (topic, str(ex)), file=sys.stderr)

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -83,20 +83,16 @@ class ImageView(TopicMessageView):
             0, 0, self._image_view.size().width() - 2, self._image_view.size().height() - 2)
         self.put_image_into_scene()
 
-    def message_viewed(self, bag, msg_details):
+    def message_viewed(self, bag, entry, ros_message, msg_type_name, topic):
         """
         refreshes the image
         """
-        TopicMessageView.message_viewed(self, bag, msg_details)
-        topic, msg, t = msg_details[:3]
-        if not msg:
-            self.set_image(None, topic, 'no message')
-        else:
-            self.set_image(msg, topic, msg.header.stamp)
+        TopicMessageView.message_viewed(self, bag, entry, ros_message, msg_type_name, topic)
+        self.set_image(ros_message, msg_type_name, topic, ros_message.header.stamp)
 
     def message_cleared(self):
         TopicMessageView.message_cleared(self)
-        self.set_image(None, None, None)
+        self.set_image(None, None, None, None)
 
     # End MessageView implementation
     def put_image_into_scene(self):
@@ -114,12 +110,10 @@ class ImageView(TopicMessageView):
             self._scene.clear()
             self._scene.addPixmap(pixmap)
 
-    def set_image(self, image_msg, image_topic, image_stamp):
-        self._image_msg = image_msg
-        if image_msg:
-            self._image = image_helper.imgmsg_to_pil(image_msg)
-        else:
-            self._image = None
-        self._image_topic = image_topic
-        self._image_stamp = image_stamp
-        self.put_image_into_scene()
+    def set_image(self, image_msg, image_type, image_topic, image_stamp):
+        if image_type == "sensor_msgs/msg/Image" or image_type == "sensor_msgs/msg/CompressedImage":
+            self._image_msg = image_msg
+            self._image = image_helper.imgmsg_to_pil(image_msg, image_type)
+            self._image_topic = image_topic
+            self._image_stamp = image_stamp
+            self.put_image_into_scene()

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -367,6 +367,7 @@ class MessageTree(QTreeWidget):
         self._msg_type = msg_type
         self._msg = None
 
+        self.keyPressEvent = self.on_key_press
         self._expanded_paths = None
         self._checked_states = set()
         self.plot_list = set()
@@ -499,6 +500,19 @@ class MessageTree(QTreeWidget):
                 subobj_type = type(subobj).__name__
 
             self._add_msg_object(item, subpath, subobj_name, subobj, subobj_type)
+
+    # Keyboard handler
+    def on_key_press(self, event):
+        key, ctrl = event.key(), event.modifiers() & Qt.ControlModifier
+        if ctrl:
+            if key == ord('C') or key == ord('c'):
+                # Ctrl-C: copy text from selected items to clipboard
+                self._copy_text_to_clipboard()
+                event.accept()
+            elif key == ord('A') or key == ord('a'):
+                # Ctrl-A: select all
+                self.expandAll()
+                self.selectAll()
 
     def handleChanged(self, item, column):
         if item.data(0, Qt.UserRole) == None:

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -362,7 +362,7 @@ class MessageTree(QTreeWidget):
     def __init__(self, msg_type, parent):
         super(MessageTree, self).__init__(parent)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.setHeaderHidden(True)
+        self.setHeaderHidden(False)
         self.itemChanged.connect(self.handleChanged)
         self._msg_type = msg_type
         self._msg = None
@@ -378,6 +378,8 @@ class MessageTree(QTreeWidget):
         return self._msg
 
     def set_message(self, msg, msg_type):
+        self.setHeaderLabel(msg_type)
+
         # Remember whether items were expanded or not before deleting
         if self._msg:
             for item in self.get_all_items():

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -429,7 +429,8 @@ class MessageTree(QTreeWidget):
             self.traverse(child, function)
 
     def _add_msg_object(self, parent, path, name, obj, obj_type):
-        label = name
+        # Remove the leading underscore for display
+        label = name[1:]
 
         if hasattr(obj, '__slots__'):
             subobjs = [(slot, getattr(obj, slot)) for slot in obj.__slots__]
@@ -501,7 +502,10 @@ class MessageTree(QTreeWidget):
         if item.data(0, Qt.UserRole) == None:
             pass
         else:
-            path = self.get_item_path(item)
+            # Strip the leading underscore from each of the path segments
+            segments = [segment[1:] for segment in self.get_item_path(item).split('.')]
+            path  = '.'.join(segments)
+
             if item.checkState(column) == Qt.Checked:
                 if path not in self.plot_list:
                     self.plot_list.add(path)


### PR DESCRIPTION
I've continued the port started a while back on the 'ros2_port' branch. All of the features should be available with this PR, but some work remains.

**The following minor improvements are included in this PR:**
- Supported 8UC1 and 32FC1 image types for display
- Display message type in Raw view and Plot view Treeview headers
- Add tooltips on the status line for "# of seconds from beginning" and "bag size"
- Pre-populate bag name for the Save dialog (as the Record dialog does)
- Add Ctrl-A/Ctrl-C handling for the plot view (to make it consistent with the raw view)
- Update the status bar correctly when reading large bags
- Reset zoom level when recording so that events fit in the timeline (dynamically updated)

**The following issues remain to be addressed:**
- Output a message if/when there is more than one type on a particular topic
- Convert the 32FC1 image type to grayscale for display
- Node selection is not working if the node is in a namespace
- Display float[] (string[] currently works)
- The Rosbag2 class assumes a SQL back-end and does direct SQL access. Instead, this should use the rosbag2_py APIs so that it will work with any database back-end.
- There is a hack to make recording work that needs to be removed. Have to figure out a way that we can be recording a rosbag and also display the items dynamically. 
- When publishing previously recorded messages, should be able to use the same QoS as when originally published and recorded. To do this, the rosbags will need to save this information first.
- Rosbags could be collected into a single file (tar file, for example). With this port, the 'rosbag' is identified by the containing directory and not a single file. 

FYI - This branch started from the 'ros2_port' branch and then rebased to the current master before making the changes. 
