### PR TITLE
Fix a bug with the status line progress bar

### DIFF
--- a/rqt_bag/src/rqt_bag/index_cache_thread.py
+++ b/rqt_bag/src/rqt_bag/index_cache_thread.py
@@ -64,8 +64,7 @@ class IndexCacheThread(threading.Thread):
                 updated = False
                 for topic in self.timeline.topics:
                     if topic in self.timeline.invalidated_caches:
-                        if self.timeline._update_index_cache(topic) > 0:
-                            updated = True
+                        updated |= (self.timeline._update_index_cache(topic) > 0)
                     if topic_num % update_step == 0 or topic_num == total_topics:
                         new_progress = int(100.0 * (float(topic_num) / total_topics))
                         if new_progress != progress:

--- a/rqt_bag/src/rqt_bag/index_cache_thread.py
+++ b/rqt_bag/src/rqt_bag/index_cache_thread.py
@@ -64,7 +64,8 @@ class IndexCacheThread(threading.Thread):
                 updated = False
                 for topic in self.timeline.topics:
                     if topic in self.timeline.invalidated_caches:
-                        updated = (self.timeline._update_index_cache(topic) > 0)
+                        if self.timeline._update_index_cache(topic) > 0:
+                            updated = True
                     if topic_num % update_step == 0 or topic_num == total_topics:
                         new_progress = int(100.0 * (float(topic_num) / total_topics))
                         if new_progress != progress:


### PR DESCRIPTION
When loading a bag with lots of topics, the progress bar was not
getting reset to 0 after the load completed. This was due to the
'updated' flag getting overwritten in the index caching thread and
not properly detecting that something had changed with the timeline.
If the last topic evaluated had no entries then it was erroneously
assumed that nothing at all had changed (for any topic).

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>