### PR TITLE
Fix issue: no vertical scroll bar until window is resized

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -38,7 +38,7 @@ import rospkg
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import qDebug, QFileInfo, Qt, qWarning, Signal
-from python_qt_binding.QtGui import QIcon
+from python_qt_binding.QtGui import QIcon, QResizeEvent
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 
 import rosbag
@@ -274,6 +274,12 @@ class BagWidget(QWidget):
             self.last_open_dir = QFileInfo(filenames[0][0]).absoluteDir().absolutePath()
         for filename in filenames[0]:
             self.load_bag(filename)
+
+        # After loading bag(s), force a resize event on the bag widget so that
+        # it can take the new height of the timeline into account (and show
+        # the scroll bar if necessary)
+        self._timeline._timeline_frame._layout()
+        self._resizeEvent(QResizeEvent(self.size(), self.size()))
 
     def load_bag(self, filename):
         qDebug("Loading '%s'..." % filename.encode(errors='replace'))


### PR DESCRIPTION
Previously, when loading a bag, if the new timeline height was larger
than the bag widget window height, the scroll bar would not show up until
the window was resized by the user. This fix forces a resize upon
opening a bag so that the new timeline height is taken into account
and the scrollbar appears if the timeline height is now greater than the
bag widget height, as expected. 

Fixes #31

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>