### PR TITLE
Simplify the playback speed display in the status line

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -357,17 +357,15 @@ class BagWidget(QWidget):
             spd = self._timeline.play_speed
             if spd != 0.0:
                 if spd > 1.0:
-                    spd_str = '>> %.0fx' % spd
+                    spd_str = '%.0fx' % spd
                 elif spd == 1.0:
-                    spd_str = '>'
+                    spd_str = '1x'
                 elif spd > 0.0:
-                    spd_str = '> 1/%.0fx' % (1.0 / spd)
+                    spd_str = '1/%.0fx' % (1.0 / spd)
                 elif spd > -1.0:
-                    spd_str = '< 1/%.0fx' % (1.0 / -spd)
-                elif spd == 1.0:
-                    spd_str = '<'
+                    spd_str = '1/%.0fx' % (1.0 / -spd)
                 else:
-                    spd_str = '<< %.0fx' % -spd
+                    spd_str = '%.0fx' % -spd
                 self.playspeed_label.setText(spd_str)
             else:
                 self.playspeed_label.setText('')


### PR DESCRIPTION
Previously, symbols (>,>>,<,<<) and numbers (2x, 1/2x, etc.) were used in
combination to represent the current playback speed. In addition, the
'1x' case showed only '>', resulting in a potentially confusing display, IMO.
Instead, the display can simply show the speed factor - 1x, 2x, 1/2x, etc.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>