### PR TITLE
Dynamically resize the timeline when recording

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -726,9 +726,6 @@ class BagTimeline(QGraphicsScene):
             self._messages_cvs[topic] = threading.Condition()
             self._message_loaders[topic] = MessageLoaderThread(self, topic)
 
-        if self._timeline_frame._stamp_left is None:
-            self.reset_zoom()
-
         # Notify the index caching thread that it has work to do
         with self._timeline_frame.index_cache_cv:
             self._timeline_frame.invalidated_caches.add(topic)
@@ -740,6 +737,10 @@ class BagTimeline(QGraphicsScene):
                     listener.timeline_changed()
                 except Exception as ex:
                     qWarning('Error calling timeline_changed on %s: %s' % (type(listener), str(ex)))
+
+        # Dynamically resize the timeline, if necessary, to make visible any new messages
+        # that might otherwise have exceeded the bounds of the window
+        self.reset_zoom()
 
     # Views / listeners
     def add_view(self, topic, frame):


### PR DESCRIPTION
Previously, when recording, once the timeline window had filled with messages,
additional messages were not displayed. Instead, the window appeared static,
even while recording continued.

Now, the timeline window incorporates any newly recorded messages, resizing
as needed in order to dynamically update the window.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>