### PR TITLE
Correctly clean up widgets in plot_view layout

### DIFF
--- a/rqt_bag/src/rqt_bag/timeline_menu.py
+++ b/rqt_bag/src/rqt_bag/timeline_menu.py
@@ -78,10 +78,10 @@ class TopicPopupWidget(QWidget):
                 self._timeline.remove_listener(self._topic, self._viewer)
                 self._viewer = None
 
-            # clean out the layout
-            while self.layout().count() > 0:
-                item = self.layout().itemAt(0)
-                self.layout().removeItem(item)
+            # Clean out the layout. Loop backwards since removing
+            # from the beginning shifts items and changes the order
+            for i in reversed(range(self.layout().count())):
+                self.layout().itemAt(i).widget().setParent(None)
 
             # create a new viewer
             self._viewer = self._viewer_type(self._timeline, self, self._topic)


### PR DESCRIPTION
Iterating over the widgets in the layout in forward order when
attempting to delete all of the widgets in a layout resulted in
some widgets not getting deleted properly. Instead, they should
be traversed in reverse order so that the index for each
widget does not change and all are deleted.

Fixes #5

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>