### PR TITLE
Fix tuples for bisect calls (#67)

### DIFF
--- a/rqt_bag/src/rqt_bag/timeline_cache.py
+++ b/rqt_bag/src/rqt_bag/timeline_cache.py
@@ -109,7 +109,7 @@ class TimelineCache(threading.Thread):
             # Attempt to get a item from the cache that's within time_threshold secs from stamp
             topic_cache = self.items.get(topic)
             if topic_cache:
-                cache_index = max(0, bisect.bisect_right(topic_cache, (stamp, None)) - 1)
+                cache_index = max(0, bisect.bisect_right(topic_cache, (stamp, )) - 1)
 
                 if cache_index <= len(topic_cache) - 1:
                     # Get cache entry before (or at) timestamp, and entry after
@@ -155,7 +155,7 @@ class TimelineCache(threading.Thread):
             if stamp in topic_item_access:
                 last_access = topic_item_access[stamp]
 
-                index = bisect.bisect_left(topic_last_accessed, (last_access, None))
+                index = bisect.bisect_left(topic_last_accessed, (last_access, ))
                 assert(topic_last_accessed[index][1] == stamp)
 
                 del topic_last_accessed[index]
@@ -172,7 +172,7 @@ class TimelineCache(threading.Thread):
                 while len(topic_cache) > self.max_cache_size:
                     lru_stamp = self.last_accessed[topic][0][1]
 
-                    cache_index = bisect.bisect_left(topic_cache, (lru_stamp, None))
+                    cache_index = bisect.bisect_left(topic_cache, (lru_stamp, ))
                     assert(topic_cache[cache_index][0] == lru_stamp)
 
                     del topic_cache[cache_index]


### PR DESCRIPTION
Python3 doesn't allow comparisons between 'NoneType' and other types like
float, generating the following error:

    TypeError: '<' not supported between instances of 'float' and 'NoneType'

This error was encountered when creating tuples for calls to bisect, where
a tuple was created using 'None'. Instead, a single element tuples are
created, which result in the correct comparison behavior.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>