### PR TITLE
Open the bag directory instead of a single file

### DIFF
--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -208,7 +208,7 @@ class MessageTree(QTreeWidget):
 
         elif type(obj) in [str, bool, int, long, float, complex, Time]:
             # Ignore any binary data
-            obj_repr = codecs.utf_8_decode(str(obj).decode(), 'ignore')[0]
+            obj_repr = codecs.utf_8_decode(str(obj).encode(), 'ignore')[0]
 
             # Truncate long representations
             if len(obj_repr) >= 50:


### PR DESCRIPTION
In ROS2, there is no longer a single rosbag file. Let the directory
containing the various files be used as the "rosbag." Also, use a
consistent proposed filename format for both the Record and Save dialogs.
Finally, fix a minor issue in the raw view.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>