### PR TITLE
Port the topic and node selection dialogs to ROS2

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -253,7 +253,7 @@ class BagWidget(QWidget):
             return
 
         # TODO Implement limiting by regex and by number of messages per topic
-        self.topic_selection = TopicSelection()
+        self.topic_selection = TopicSelection(self._timeline._context.node)
         self.topic_selection.recordSettingsSelected.connect(self._on_record_settings_selected)
 
     def _on_record_settings_selected(self, all_topics, selected_topics):

--- a/rqt_bag/src/rqt_bag/node_selection.py
+++ b/rqt_bag/src/rqt_bag/node_selection.py
@@ -63,7 +63,7 @@ class NodeSelection(QWidget):
     def addCheckBox(self, node):
         node_name = node[0]
         node_namespace = node[1]
-        name = node_namespace + node_name if (node_namespace == '/') else node_namespace + '/' + node_name
+        name = node_namespace + node_name if (node_namespace[-1] == '/') else node_namespace + '/' + node_name
         item = QCheckBox(name, self)
         item.stateChanged.connect(lambda x: self.updateNode(x, node))
         self.selection_vlayout.addWidget(item)

--- a/rqt_bag/src/rqt_bag/topic_selection.py
+++ b/rqt_bag/src/rqt_bag/topic_selection.py
@@ -32,7 +32,7 @@
 
 from python_qt_binding.QtCore import Qt, Signal
 from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
-#from .node_selection import NodeSelection
+from .node_selection import NodeSelection
 
 
 class TopicSelection(QWidget):
@@ -58,17 +58,17 @@ class TopicSelection(QWidget):
         self.from_nodes_button = QPushButton("From Nodes", self)
         self.from_nodes_button.clicked.connect(self.onFromNodesButtonClicked)
 
-        self.main_vlayout = QVBoxLayout(self)
+        self.main_vlayout = QVBoxLayout()
         self.main_vlayout.addWidget(self.area)
         self.main_vlayout.addWidget(self.ok_button)
         self.main_vlayout.addWidget(self.from_nodes_button)
         self.setLayout(self.main_vlayout)
 
-        self.selection_vlayout = QVBoxLayout(self)
+        self.selection_vlayout = QVBoxLayout()
         self.item_all = QCheckBox("All", self)
         self.item_all.stateChanged.connect(self.updateList)
         self.selection_vlayout.addWidget(self.item_all)
-        topic_data_list = self._node.get_topics_and_topic_types()
+        topic_data_list = self._node.get_topic_names_and_types()
         topic_data_list.sort()
         for topic, datatype in topic_data_list:
             self.addCheckBox(topic)
@@ -122,4 +122,4 @@ class TopicSelection(QWidget):
             self.item_all.checkState() == Qt.Checked, self.selected_topics)
 
     def onFromNodesButtonClicked(self):
-        self.node_selection = NodeSelection(self)
+        self.node_selection = NodeSelection(self, self._node)


### PR DESCRIPTION
Get rid of a couple Qt-related warnings in the process - Don't
have to pass in the parent node if explicity setting the layout.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>