### PR TITLE
Enable recording for ROS2

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -711,16 +711,14 @@ class BagTimeline(QGraphicsScene):
 
     def record_bag(self, filename, all=True, topics=[], regex=False, limit=0):
         try:
-            self._recorder = Recorder(
-                filename, bag_lock=self._bag_lock, all=all, topics=topics, regex=regex, limit=limit)
+            self._recorder = Recorder(self._context.node, filename, bag_lock=self._bag_lock,
+                    all=all, topics=topics, regex=regex, limit=limit)
         except Exception as ex:
             qWarning('Error opening bag for recording [%s]: %s' % (filename, str(ex)))
             return
 
         self._recorder.add_listener(self._message_recorded)
-
-        self.add_bag(self._recorder.bag)
-
+        self.add_bag(self._recorder._bag)
         self._recorder.start()
 
         self.wrap = False

--- a/rqt_bag/src/rqt_bag/qos.py
+++ b/rqt_bag/src/rqt_bag/qos.py
@@ -47,7 +47,7 @@ from rclpy.time import Time
 def duration_to_node(duration):
     t = Time(nanoseconds=duration.nanoseconds)
     node = {}
-    (node["sec"], node["nsec"]) = t.seconds_nanoseconds()
+    (node['sec'], node['nsec']) = t.seconds_nanoseconds()
     return node
 
 

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -156,8 +156,12 @@ class Recorder(object):
                                                           offered_qos_profiles=offered_qos_profiles)
                 self._rosbag_writer.create_topic(topic_metadata)
 
-        # Create a metadata dictionary sufficient to create a Rosbag2 object. The rosbag_writer
-        # doesn't create this file until it is destroyed.
+        # Create a metadata dictionary (bag_info) sufficient to create a Rosbag2 object. Normally,
+        # Rosbag2 is used to open an existing database, but in this case, it's a new database
+        # that hasn't been populated yet and we don't yet have a metadata.yaml file to use (the
+        # metadata.yaml file is created when the rosbag_writer is closed). We could also close
+        # the rosbag_writer and then open it again, but this works for now; the code is going
+        # to be refactored anyway to combine rosbag_writer/Rosbag2 functionality.
         topic_info['message_count'] = 0
         bag_info['relative_file_paths'] = []
         bag_name = os.path.split(filename)[1]

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -32,29 +32,39 @@
 
 """
 Recorder subscribes to ROS messages and writes them to a bag file.
-TODO (brawner) Port to ROS2. Blocked by missing rclpy rosbag2 interface.
 """
 
 from __future__ import print_function
 try:
     from queue import Queue
+    from queue import Empty
 except ImportError:
     from Queue import Queue
+    from Queue import Empty
 import re
 import threading
 import time
-
-#import rosbag
-#import rosgraph
-#import roslib
-#import rospy
-
 import sys
+import rosbag2_py
+import yaml
+import os
+
+from rosbag2_transport import rosbag2_transport_py
+from .rosbag2 import Rosbag2
+from rclpy.qos import qos_profile_system_default
+from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
+from rosidl_runtime_py.utilities import get_message
+from rclpy.serialization import serialize_message
+from rclpy.duration import Duration
+from rqt_bag import bag_helper
+from rclpy.time import Time
+from rclpy.clock import Clock, ClockType
+from rclpy.qos import QoSHistoryPolicy, QoSDurabilityPolicy, QoSReliabilityPolicy, QoSLivelinessPolicy
 
 
 class Recorder(object):
 
-    def __init__(self, filename, bag_lock=None, all=True, topics=[], regex=False, limit=0,
+    def __init__(self, node, filename, bag_lock=None, all=True, topics=[], regex=False, limit=0,
                  master_check_interval=1.0):
         """
         Subscribe to ROS messages and record them to a bag file.
@@ -74,13 +84,67 @@ class Recorder(object):
             publications [default: 1]
         @type  master_check_interval: float
         """
+        self._node = node
         self._all = all
         self._topics = topics
         self._regex = regex
         self._limit = limit
         self._master_check_interval = master_check_interval
+        self._serialization_format='cdr'
+        self._storage_id = 'sqlite3'
+        self._bag_filename = filename
 
-        self._bag = rosbag.Bag(filename, 'w')
+        ################################################################
+        # TODO(mjeronimo): Need to unify the direct database access of the current Rosbag2
+        # implementation and the rosbag_writer into a single Rosbag2 class
+        storage_options = rosbag2_py.StorageOptions(uri=filename, storage_id=self._storage_id)
+        converter_options = rosbag2_py.ConverterOptions(
+            input_serialization_format=self._serialization_format,
+            output_serialization_format=self._serialization_format)
+        self._rosbag_writer = rosbag2_py.SequentialWriter()
+        self._rosbag_writer.open(storage_options, converter_options)
+
+        # TODO(mjeronimo):
+        # A hack here to create a metadata dictionary (usually read from the one created for the
+        # database) sufficient to create a Rosbag2 object. The rosbag_writer won't create this file
+        # until the object is destroyed. Unfortunately, the writer is kept open so that it can write
+        # out messages as they are received.
+        bag_info = {}
+        bag_info['topics_with_message_count'] = []
+        for topic, msg_type_names in self.get_topic_names_and_types():
+            if topic in topics:
+                topic_info = {}
+                topic_info['topic_metadata'] = {}
+                topic_info['topic_metadata']['name'] = topic
+
+                # TODO(mjeronimo): could have multiple type names
+                topic_info['topic_metadata']['type'] = msg_type_names[0]
+                topic_info['topic_metadata']['serialization_format'] = self._serialization_format
+
+                # TODO(mjeronimo): add the offered_qos_profiles
+                topic_info['topic_metadata']['offered_qos_profiles'] = ""
+                bag_info['topics_with_message_count'].append(topic_info)
+
+                # Add the topic to the database
+                # TODO(mjeronimo): need qos info here when creating the topic
+                topic_metadata = rosbag2_py.TopicMetadata(name=topic, type=msg_type_names[0],
+                                                          serialization_format=self._serialization_format)
+
+                self._rosbag_writer.create_topic(topic_metadata)
+
+        topic_info['message_count'] = 0
+        bag_info['relative_file_paths'] = []
+        bag_name = os.path.split(filename)[1]
+        bag_info['relative_file_paths'].append(bag_name + "_0.db3")
+        bag_info['starting_time'] = {}
+        now = Clock(clock_type=ClockType.SYSTEM_TIME).now()
+        bag_info['starting_time']['nanoseconds_since_epoch'] = now.nanoseconds
+        bag_info['duration'] = {}
+        bag_info['duration']['nanoseconds'] = 0
+
+        self._bag = Rosbag2(bag_info, filename + "/metadata.yaml")
+        ################################################################
+
         self._bag_lock = bag_lock if bag_lock else threading.Lock()
         self._listeners = []
         self._subscriber_helpers = {}
@@ -99,13 +163,8 @@ class Recorder(object):
             self._regexes = None
 
         self._message_count = {}  # topic -> int (track number of messages recorded on each topic)
-
         self._master_check_thread = threading.Thread(target=self._run_master_check)
         self._write_thread = threading.Thread(target=self._run_write)
-
-    @property
-    def bag(self):
-        return self._bag
 
     def add_listener(self, listener):
         """
@@ -147,34 +206,39 @@ class Recorder(object):
 
     # Implementation
 
-    def _run_master_check(self):
-        master = rosgraph.Master('rqt_bag_recorder')
+    def get_topic_names_and_types(self, include_hidden_topics=False):
+        topic_names_and_types = self._node.get_topic_names_and_types()
+        if not include_hidden_topics:
+            topic_names_and_types = [
+                (n, t) for (n, t) in topic_names_and_types
+                if not topic_or_service_is_hidden(n)]
+        return topic_names_and_types
 
+
+    def _run_master_check(self):
         try:
             while not self._stop_flag:
                 # Check for new topics
-                for topic, datatype in master.getPublishedTopics(''):
+                for topic, msg_type_names in self.get_topic_names_and_types():
                     # Check if:
                     #    the topic is already subscribed to, or
                     #    we've failed to subscribe to it already, or
                     #    we've already reached the message limit, or
                     #    we don't want to subscribe
-                    if topic in self._subscriber_helpers or \
-                            topic in self._failed_topics or \
-                            topic in self._limited_topics or \
-                            not self._should_subscribe_to(topic):
-                        continue
+                    for msg_type_name in msg_type_names:
+                        if topic in self._subscriber_helpers or \
+                                topic in self._failed_topics or \
+                                topic in self._limited_topics or \
+                                not self._should_subscribe_to(topic):
+                            continue
 
-                    try:
-                        pytype = roslib.message.get_message_class(datatype)
-
-                        self._message_count[topic] = 0
-
-                        self._subscriber_helpers[topic] = _SubscriberHelper(self, topic, pytype)
-                    except Exception as ex:
-                        print('Error subscribing to %s (ignoring): %s' %
-                              (topic, str(ex)), file=sys.stderr)
-                        self._failed_topics.add(topic)
+                        try:
+                            self._message_count[topic] = 0
+                            self._subscriber_helpers[topic] = _SubscriberHelper(self._node, self, topic, msg_type_name)
+                        except Exception as ex:
+                            print('Error subscribing to %s (ignoring): %s' %
+                                  (topic, str(ex)), file=sys.stderr)
+                            self._failed_topics.add(topic)
 
                 # Wait a while
                 self._stop_condition.acquire()
@@ -186,12 +250,6 @@ class Recorder(object):
         # Unsubscribe from all topics
         for topic in list(self._subscriber_helpers.keys()):
             self._unsubscribe(topic)
-
-        # Close the bag file so that the index gets written
-        try:
-            self._bag.close()
-        except Exception as ex:
-            print('Error closing bag [%s]: %s' % (self._bag.filename, str(ex)))
 
     def _should_subscribe_to(self, topic):
         if self._all:
@@ -208,13 +266,13 @@ class Recorder(object):
 
     def _unsubscribe(self, topic):
         try:
-            self._subscriber_helpers[topic].subscriber.unregister()
+             self._node.destroy_subscription(self, self._subscriber_helpers[topic].subscriber)
         except Exception:
             return
 
         del self._subscriber_helpers[topic]
 
-    def _record(self, topic, m):
+    def _record(self, topic, msg, msg_type_name):
         if self._paused:
             return
 
@@ -223,27 +281,57 @@ class Recorder(object):
             self._unsubscribe(topic)
             return
 
-        self._write_queue.put((topic, m, rospy.get_rostime()))
+        now = Clock(clock_type=ClockType.SYSTEM_TIME).now()
+        self._write_queue.put((topic, msg, msg_type_name, now))
         self._message_count[topic] += 1
 
     def _run_write(self):
         try:
+            poll_interval = 1.0
             while not self._stop_flag:
-                # Wait for a message
-                item = self._write_queue.get()
+                try:
+                    item = self._write_queue.get(block=False)
+                except Empty:
+                    time.sleep(poll_interval)
+                    continue
 
                 if item == self:
                     continue
 
-                topic, m, t = item
+                topic, msg, msg_type_name, t = item
 
                 # Write to the bag
                 with self._bag_lock:
-                    self._bag.write(topic, m, t)
+                    # HERE:
+                    helper = self._subscriber_helpers[topic]
+                    #print(str(helper.qos_profile))
+
+                    qos_dict = {}
+                    qos_dict["history"] = 0 # helper.qos_profile.history
+                    qos_dict["depth"] = helper.qos_profile.depth
+                    qos_dict["reliability"] = 1 # helper.qos_profile.reliability
+                    qos_dict["durability"] = 1 # helper.qos_profile.durability
+                    qos_dict["lifespan"] = 0 # helper.qos_profile.lifespan
+                    qos_dict["deadline"] = 0 # helper.qos_profile.deadline
+                    qos_dict["liveliness"] = 1 # helper.qos_profile.liveliness
+                    qos_dict["liveliness_lease_duration"] = 0 # helper.qos_profile.liveliness_lease_duration
+                    qos_dict["avoid_ros_namespace_conventions"] = helper.qos_profile.avoid_ros_namespace_conventions
+
+                    print(qos_dict)
+                    qos_profile_yaml = yaml.dump([qos_dict], sort_keys=False)
+
+                    topic_metadata = rosbag2_py.TopicMetadata(name=topic, type=msg_type_name, serialization_format=self._serialization_format, offered_qos_profiles=qos_profile_yaml)
+                    self._rosbag_writer.create_topic(topic_metadata)
+
+                    serialized_msg = serialize_message(msg)
+                    self._rosbag_writer.write(topic, serialized_msg, t.nanoseconds)
+
+                    duration_ns = t.nanoseconds - self._bag.start_time.nanoseconds
+                    self._bag.duration = Duration(nanoseconds=duration_ns)
 
                 # Notify listeners that a message has been recorded
                 for listener in self._listeners:
-                    listener(topic, m, t)
+                    listener(topic, msg, t)
 
         except Exception as ex:
             print('Error write to bag: %s' % str(ex), file=sys.stderr)
@@ -251,11 +339,60 @@ class Recorder(object):
 
 class _SubscriberHelper(object):
 
-    def __init__(self, recorder, topic, pytype):
+    def __init__(self, node, recorder, topic, msg_type_name):
+        self.node = node
         self.recorder = recorder
         self.topic = topic
+        self.msg_type_name = msg_type_name
+        self.msg_type = get_message(msg_type_name)
 
-        self.subscriber = rospy.Subscriber(self.topic, pytype, self.callback)
+        # Attempt to use the same QoS settings as the publisher (?)
+        info = node.get_publishers_info_by_topic(topic)
+        if info:
+            self.qos_profile = info[0].qos_profile
 
-    def callback(self, m):
-        self.recorder._record(self.topic, m)
+            self.qos_profile.history = QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT
+            self.qos_profile.depth = 0
+            #self.qos_profile.reliability = QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT
+            #self.qos_profile.durability = QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT
+            self.qos_profile.lifespan = Duration(nanoseconds=0)
+            self.qos_profile.deadline = Duration(nanoseconds=0)
+            #self.qos_profile.liveliness = QoSLivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT
+            self.qos_profile.liveliness_lease_duration = Duration(nanoseconds=0)
+            #self.qos_profile.avoid_ros_namespace_conventions = False
+
+            self.subscriber = node.create_subscription(self.msg_type, topic, self.callback, self.qos_profile)
+
+
+    def callback(self, msg):
+        self.recorder._record(self.topic, msg, self.msg_type_name)
+
+
+
+#print("topic: {}".format(topic))
+#print(" my qos")
+#print(self.qos_profile)
+#print("\n")
+#print(" system_default:")
+#print(qos_profile_system_default)
+
+#
+# std::string Recorder::serialized_offered_qos_profiles_for_topic(const std::string & topic_name)
+# {
+#   YAML::Node offered_qos_profiles;
+#   auto endpoints = node_->get_publishers_info_by_topic(topic_name);
+#   for (const auto & info : endpoints) {
+#     offered_qos_profiles.push_back(Rosbag2QoS(info.qos_profile()));
+#   }
+#   return YAML::Dump(offered_qos_profiles);
+# }
+# 
+# rclcpp::QoS Recorder::subscription_qos_for_topic(const std::string & topic_name) const
+# {
+#   if (topic_qos_profile_overrides_.count(topic_name)) {
+#     return topic_qos_profile_overrides_.at(topic_name);
+#   }
+#   return Rosbag2QoS::adapt_request_to_offers(
+#     topic_name, node_->get_publishers_info_by_topic(topic_name));
+# }
+# 

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -253,6 +253,13 @@ class Recorder(object):
         for topic in list(self._subscriber_helpers.keys()):
             self._unsubscribe(topic)
 
+        # Explicitly delete the rosbag writer so that the database is properly closed
+        # and the metadata.yaml file is written
+        try:
+            del self._rosbag_writer
+        except Exception as ex:
+            print('Error closing bag [%s]: %s' % (self._bag.filename, str(ex)))
+
     def _should_subscribe_to(self, topic):
         if self._all:
             return True

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -45,21 +45,22 @@ import re
 import threading
 import time
 import sys
-import rosbag2_py
 import yaml
 import os
 
+import rosbag2_py
+
 from rosbag2_transport import rosbag2_transport_py
-from .rosbag2 import Rosbag2
-from rclpy.qos import qos_profile_system_default
-from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rosidl_runtime_py.utilities import get_message
 from rclpy.serialization import serialize_message
 from rclpy.duration import Duration
-from rqt_bag import bag_helper
+from rclpy.qos import qos_profile_system_default
+from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rclpy.time import Time
 from rclpy.clock import Clock, ClockType
 from rclpy.qos import QoSHistoryPolicy, QoSDurabilityPolicy, QoSReliabilityPolicy, QoSLivelinessPolicy
+from rqt_bag import bag_helper
+from .rosbag2 import Rosbag2
 from .qos import get_qos_profiles_for_topic, gen_subscriber_qos_profile, qos_profiles_to_yaml
 
 
@@ -303,9 +304,8 @@ class Recorder(object):
             poll_interval = 1.0
             while not self._stop_flag:
                 try:
-                    item = self._write_queue.get(block=False)
+                    item = self._write_queue.get(block=False, timeout=poll_interval)
                 except Empty:
-                    time.sleep(poll_interval)
                     continue
 
                 if item == self:


### PR DESCRIPTION
This PR implements recording for ROS2. Subsequently, it should be possible to replace
almost all of this code with a call to rosbag2_transport_py.record provided we add the ability
to receive a callback upon a write so that we can populate the bag timeline in the UI. That will
also have the benefit of uniformity with ros2 bag record. Also, it should be possible to eliminate
the Rosbag2 class by adding any missing functionality to the rosbag_reader and/or
rosbag_writer classes. These will be the next two steps for rqt_bag on ROS2. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>
