### PR TITLE
Fix exec_depend.

### DIFF
--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -16,7 +16,7 @@
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2_py</exec_depend>
-  <exec_depend>rosbag2_transport_py</exec_depend>
+  <exec_depend>rosbag2_transport</exec_depend>
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 


### PR DESCRIPTION
The package name is rosbag2_transport, not rosbag2_transport_py

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing CI builds, like: http://build.ros2.org/view/Rci/job/Rci__nightly-release_ubuntu_focal_amd64/144/