### PR TITLE
Refactor the Rosbag2 class

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_helper.py
+++ b/rqt_bag/src/rqt_bag/bag_helper.py
@@ -30,111 +30,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""
-Helper functions for bag files and timestamps.
-"""
+"""Helper functions for bag files and timestamps."""
 
 from decimal import Decimal
-import math
-import time
-
-import rclpy
-from rclpy.duration import Duration
-from rclpy.time import Time
-
-
-def stamp_to_str(t):
-    """
-    Convert a rclpy.time.Time to a human-readable string.
-
-    @param t: time to convert
-    @type  t: rclpy.time.Time
-    """
-    t_sec, t_nsec = t.seconds_nanoseconds()
-    if t_sec < (60 * 60 * 24 * 365 * 5):
-        # Display timestamps earlier than 1975 as seconds
-        return '%.3fs' % t_sec
-    else:
-        return time.strftime('%b %d %Y %H:%M:%S', time.localtime(t_sec)) + '.%03d' % (t_nsec * 1e-9)
-
-
-def get_topics(bag):
-    """
-    Get an alphabetical list of all the unique topics in the bag.
-
-    @return: sorted list of topics
-    @rtype:  list of str
-    """
-    return sorted(bag.get_topics())
-
-
-def get_start_stamp(bag):
-    """
-    Get the earliest timestamp in the bag.
-
-    @param bag: bag file
-    @type  bag: rosbag.Bag
-    @return: earliest timestamp
-    @rtype:  rclpy.time.Time
-    """
-    return bag.start_time
-
-
-def get_end_stamp(bag):
-    """
-    Get the latest timestamp in the bag.
-
-    @param bag: bag file
-    @type  bag: rosbag.Bag
-    @return: latest timestamp
-    @rtype:  rclpy.time.Time
-    """
-    return bag.start_time + bag.duration
-
-
-def get_topics_by_datatype(bag):
-    """
-    Get all the message types in the bag and their associated topics.
-
-    @param bag: bag file
-    @type  bag: rosbag.Bag
-    @return: mapping from message typename to list of topics
-    @rtype:  dict of str to list of str
-    """
-    topics_by_datatype = {}
-    for name, topic in bag.topics.items():
-        topics_by_datatype.setdefault(topic['topic_metadata']['type'], []).append(name)
-
-    return topics_by_datatype
-
-
-def get_datatype(bag, topic):
-    """
-    Get the datatype of the given topic.
-
-    @param bag: bag file
-    @type  bag: rosbag.Bag
-    @return: message typename
-    @rtype:  str
-    """
-    if topic not in bag.topics:
-        return None
-    return bag.topics[topic]['topic_metadata']['type']
-
-
-def filesize_to_str(size):
-    size_name = ('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
-    i = int(math.floor(math.log(size, 1024)))
-    p = math.pow(1024, i)
-    s = round(size / p, 2)
-    if s > 0:
-        return '%s %s' % (s, size_name[i])
-    return '0 B'
 
 
 def to_sec(t):
-    """
-    Convert an rclpy.time.Time or rclpy.duration.Duration to a float representing seconds
+    """Convert an rclpy.time.Time or rclpy.duration.Duration to a float representing seconds.
 
     @param t:
     @type  t: rclpy.time.Time or rclpy.duration.Duration:

--- a/rqt_bag/src/rqt_bag/message_loader_thread.py
+++ b/rqt_bag/src/rqt_bag/message_loader_thread.py
@@ -93,7 +93,7 @@ class MessageLoaderThread(threading.Thread):
                 messages_cv.notify_all()      # notify all views that a message is loaded
 
     def _get_message(self, bag, position):
-        key = '%s%s' % (bag.filename, str(position))
+        key = '%s%s' % (bag.bag_path, str(position))
         if key in self._message_cache:
             return self._message_cache[key]
 

--- a/rqt_bag/src/rqt_bag/player.py
+++ b/rqt_bag/src/rqt_bag/player.py
@@ -129,13 +129,12 @@ class Player(QObject):
         if self.timeline.play_speed <= 0.0:
             return
 
-        (ros_message, _, topic) = bag.convert_entry_to_ros_message(entry)
+        (ros_message, _, topic) = bag.deserialize_entry(entry)
 
         # Create publisher if this is the first message on the topic
         if topic not in self._publishers:
-            topic_id = bag.get_topic_id(topic)
-            (topic_name, topic_type, serialization_format, offered_qos_profiles) = bag.get_topic_info(topic_id)
-            self.create_publisher(topic, ros_message, offered_qos_profiles)
+            topic_metadata = bag.get_topic_metadata(topic)
+            self.create_publisher(topic, ros_message, topic_metadata.offered_qos_profiles)
 
         if self._publish_clock:
             time_msg = Time()

--- a/rqt_bag/src/rqt_bag/plugins/message_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/message_view.py
@@ -93,7 +93,7 @@ class MessageView(QObject):
         """
         bag, entry = event.data
         if entry:
-            (ros_message, msg_type_name, topic) = bag.convert_entry_to_ros_message(entry)
+            (ros_message, msg_type_name, topic) = bag.deserialize_entry(entry)
             self.message_viewed(bag=bag, entry=entry, ros_message=ros_message, msg_type_name=msg_type_name, topic=topic)
         else:
             self.message_cleared()

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -160,7 +160,7 @@ class ImageTimelineRenderer(TimelineRenderer):
         if not entry:
             return None, None
 
-        (ros_message, msg_type, topic) = bag.convert_entry_to_ros_message(entry)
+        (ros_message, msg_type, topic) = bag.deserialize_entry(entry)
 
         # Convert from ROS image to PIL image
         try:

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -180,7 +180,7 @@ class PlotWidget(QWidget):
                 start_time = Time(nanoseconds=entry.timestamp)
 
         self.bag = bag
-        (ros_message, msg_type, topic) = self.bag.convert_entry_to_ros_message(entry)
+        (ros_message, msg_type, topic) = self.bag.deserialize_entry(entry)
         self.message_tree.set_message(ros_message, msg_type)
 
         # state used by threaded resampling
@@ -206,9 +206,9 @@ class PlotWidget(QWidget):
 
     def load_data(self):
         """get a generator for the specified time range on our bag"""
-        return self.bag._get_entries(self.start_stamp + Duration(seconds=self.limits[0]),
-                                     self.start_stamp + Duration(seconds=self.limits[1]),
-                                     self.msgtopic)
+        return self.bag.get_entries_in_range(self.start_stamp + Duration(seconds=self.limits[0]),
+                                             self.start_stamp + Duration(seconds=self.limits[1]),
+                                             self.msgtopic)
 
     def resample_data(self, fields):
         if self.resample_thread:
@@ -252,7 +252,7 @@ class PlotWidget(QWidget):
                 if not self.resampling_active:
                     return
 
-                (ros_message, _, _) = self.bag.convert_entry_to_ros_message(entry)
+                (ros_message, _, _) = self.bag.deserialize_entry(entry)
                 timestamp = Time(nanoseconds=entry.timestamp)
 
                 for path in self.resample_fields:


### PR DESCRIPTION
In preparation to switch to rclpy's SequentialWriter, clean up the Rosbag2 class.

* Merge the rosbag-related utility functions from bag_helper
* Add pydoc comments
* Clean up ament_flake8 issues
* Simplify the SQL query code
* Clean up the interface and remove any redundant functionality

The next step is to use the SequentialWriter, but in order to do that, we'll need that class to support the kinds of queries we're doing in this module:

* getting an entry for particular timestamp
* get the entry after a specific timestamp
* get the entries in a range (starting and ending timestamps)

One possibility for this is to extend rosbag2's StorageFilter class to allow for this kind of filtering.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>