### PR TITLE
Reset timeline zoom after loading a new bag.

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -311,6 +311,8 @@ class BagWidget(QWidget):
             qDebug("Done loading '%s'" % filename.encode(errors='replace'))
             # put the progress bar back the way it was
             self.set_status_text.emit("")
+            # reset zoom to show entirety of all loaded bags
+            self._timeline.reset_zoom()
         except rosbag.ROSBagException as e:
             qWarning("Loading '%s' failed due to: %s" % (filename.encode(errors='replace'), e))
             self.set_status_text.emit("Loading '%s' failed due to: %s" % (filename, e))


### PR DESCRIPTION
Otherwise the zoom is at the size of the first bag's timeline.