### PR TITLE
Reset timeline zoom after loading a new bag.

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -331,6 +331,8 @@ class BagWidget(QWidget):
         qDebug("Done loading '%s'" % filename.encode(errors='replace'))
         # put the progress bar back the way it was
         self.set_status_text.emit("")
+        # reset zoom to show entirety of all loaded bags
+        self._timeline.reset_zoom()
 
         # self.progress_bar.setFormat(progress_format)
         # self.progress_bar.setTextVisible(progress_text_visible) # causes a segfault :(


### PR DESCRIPTION
Otherwise the zoom is at the size of the first bag's timeline.