### PR TITLE
Fixed publisher creation error

### DIFF
--- a/rqt_bag/src/rqt_bag/qos.py
+++ b/rqt_bag/src/rqt_bag/qos.py
@@ -76,17 +76,18 @@ def qos_profiles_to_yaml(qos_profiles):
 def yaml_to_qos_profiles(profiles_yaml):
     qos_profiles = []
     nodes = yaml.safe_load(profiles_yaml)
-    for node in nodes:
-        qos_profile = QoSProfile(depth=int(node['depth']))
-        qos_profile.history = int(node['history'])
-        qos_profile.reliability = int(node['reliability'])
-        qos_profile.durability = int(node['durability'])
-        qos_profile.lifespan = node_to_duration(node['lifespan'])
-        qos_profile.deadline = node_to_duration(node['deadline'])
-        qos_profile.liveliness = int(node['liveliness'])
-        qos_profile.liveliness_lease_duration = node_to_duration(node['liveliness_lease_duration'])
-        qos_profile.avoid_ros_namespace_conventions = node['avoid_ros_namespace_conventions']
-        qos_profiles.append(qos_profile)
+    if nodes is not None:
+      for node in nodes:
+          qos_profile = QoSProfile(depth=int(node['depth']))
+          qos_profile.history = int(node['history'])
+          qos_profile.reliability = int(node['reliability'])
+          qos_profile.durability = int(node['durability'])
+          qos_profile.lifespan = node_to_duration(node['lifespan'])
+          qos_profile.deadline = node_to_duration(node['deadline'])
+          qos_profile.liveliness = int(node['liveliness'])
+          qos_profile.liveliness_lease_duration = node_to_duration(node['liveliness_lease_duration'])
+          qos_profile.avoid_ros_namespace_conventions = node['avoid_ros_namespace_conventions']
+          qos_profiles.append(qos_profile)
 
     return qos_profiles
 


### PR DESCRIPTION
With some rosbags, I had en error where the publisher could not be created when re-playing them :
`[ERROR] [1648645025.626918903] [rqt_gui_py_node_7655.rqt_bag.Player]: Error creating publisher on topic /scan for type <class 'sensor_msgs.msg._laser_scan.LaserScan'>. `
`Error text: 'NoneType' object is not iterable`
`Traceback (most recent call last):`
`  File "/opt/ros/galactic/lib/python3.8/site-packages/rqt_bag/player.py", line 163, in event`
`    self.message_viewed(bag, entry)`
`  File "/opt/ros/galactic/lib/python3.8/site-packages/rqt_bag/player.py", line 151, in message_viewed`
`    self._publishers[topic].publish(ros_message)`
`KeyError: '/scan'`

I made a simple fix, which may not be the most appropriate, but does works