### PR TITLE
comment on message loaders notify (was message listeners before)

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -757,7 +757,7 @@ class BagTimeline(QGraphicsScene):
 
         self._message_listener_threads[(topic, listener)] = \
             MessageListenerThread(self, topic, listener)
-        # Notify the message listeners
+        # Notify the message loaders to get them ready
         self._message_loaders[topic].reset()
         with self._playhead_positions_cvs[topic]:
             self._playhead_positions_cvs[topic].notify_all()


### PR DESCRIPTION
the `_playhead_positions_cvs` condition variables are consumed by the message loader threads. While the member function `add_listener(self,topic,listener)` of the bag_timeline is the producer of these condition variables, thus sending notify signal to all the loader threads.
The comment was wrong before: "# Notify the message listeners"
The comment I suggest is instead: "# Notify the message loaders to get them ready" to explain that the loaders are notified, and since it can be misleading from a function named `add_listener`, I also stress the fact that it's to prepare them to load the message and, in turn, notify the listener threads.