### PR TITLE
Fix toggle thumbnails button

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -232,7 +232,7 @@ class BagWidget(QWidget):
         self._timeline.navigate_end()
 
     def _handle_thumbs_clicked(self, checked):
-        self._timeline._timeline_frame.toggle_renderers()
+        self._timeline._timeline_frame.set_renderers_active(checked)
 
     def _handle_zoom_all_clicked(self):
         self._timeline.reset_zoom()

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -840,11 +840,6 @@ class TimelineFrame(QGraphicsItem):
     def is_renderer_active(self, topic):
         return topic in self._rendered_topics
 
-    def toggle_renderers(self):
-        idle_renderers = len(self._rendered_topics) < len(self.topics)
-
-        self.set_renderers_active(idle_renderers)
-
     def set_renderers_active(self, active):
         if active:
             for topic in self.topics:


### PR DESCRIPTION
Depends on https://github.com/ros-visualization/rqt_bag/pull/116.

Fix of minor bug I found while using rqt_bag.

The condition to check if to activate or deactivate the thumbnails was almost always false, because `len(self._rendered_topics) < len(self.topics)` will always be true if some of the topics datatypes do not support rendering.
Now, it toggles thumbnails based on the previous state of the button.