### PR TITLE
Disable reading from bag while recording - use direct caching to index for timeline

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -723,10 +723,9 @@ class BagTimeline(QGraphicsScene):
             self._messages_cvs[topic] = threading.Condition()
             self._message_loaders[topic] = MessageLoaderThread(self, topic)
 
-        # Notify the index caching thread that it has work to do
+        # Send new message info to the cache
         with self._timeline_frame.index_cache_cv:
-            self._timeline_frame.invalidated_caches.add(topic)
-            self._timeline_frame.index_cache_cv.notify()
+            self._timeline_frame.cache_message(topic, t)
 
         if topic in self._listeners:
             for listener in self._listeners[topic]:

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -899,6 +899,19 @@ class TimelineFrame(QGraphicsItem):
 
         return len(topic_cache) - topic_cache_len
 
+
+    def cache_message(self, topic, t):
+        """
+        Updates the cache of message timestamps with a specific new message,
+        bypassing any need to read entries from the bag.
+        """
+        if self._start_stamp is None or self._end_stamp is None:
+            return 0
+
+        topic_cache = self.index_cache.setdefault(topic, [])
+        topic_cache.append(bag_helper.to_sec(t))
+
+
     def _find_regions(self, stamps, max_interval):
         """
         Group timestamps into regions connected by timestamps less than max_interval secs apart


### PR DESCRIPTION
Part of #121
RFC: This covers the Recording functionality for #121.  Draft PR for consideration, feeling out opposition on whether the proposed tradeoff is acceptable.


## Description

Rosbag2 doesn't actually support reading-while-writing. The current code goes around this limitation by making queries directly into the SQLite database, but MCAP is now growing in usage as a rosbag2 storage format, so we need rqt_bag to support strictly the rosbag2 API.

For now, I believe it is a worthwhile tradeoff to lose the RawView/PlotView on bags currently recording, in order to gain support for all storage implementations. From what I can tell, the PlotView only shows "data-until-now" when opened, and cannot refresh data, so the panel needs to be closed and reopened to see new data. RawView likewise does not update while recording, since the playhead does not advance - though the user can click in.

