### PR TITLE
Use rosbag2_py API instead of metadata.yaml + sqlite3

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -723,10 +723,9 @@ class BagTimeline(QGraphicsScene):
             self._messages_cvs[topic] = threading.Condition()
             self._message_loaders[topic] = MessageLoaderThread(self, topic)
 
-        # Notify the index caching thread that it has work to do
+        # Send new message info to the cache
         with self._timeline_frame.index_cache_cv:
-            self._timeline_frame.invalidated_caches.add(topic)
-            self._timeline_frame.index_cache_cv.notify()
+            self._timeline_frame.cache_message(topic, t)
 
         if topic in self._listeners:
             for listener in self._listeners[topic]:

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -312,7 +312,7 @@ class BagTimeline(QGraphicsScene):
         Access a bag entry
         :param t: time, ''rclpy.time.Time''
         :param topic: the topic to be accessed, ''str''
-        :return: tuple of (bag, entry) corresponding to time t and topic, ''(rosbag2.bag, msg)''
+        :return: tuple of (bag, entry) closest less than or equal to t, ''(rosbag2.bag, msg)''
         """
         with self._bag_lock:
             entry_bag, entry = None, None
@@ -327,16 +327,9 @@ class BagTimeline(QGraphicsScene):
         """
         Access a bag entry
         :param t: time, ''rclpy.time.Time''
-        :return: tuple of (bag, entry) corresponding to time t, ''(rosbag2.bag, msg)''
+        :return: tuple of (bag, entry) closest less than but not equal to t, ''(rosbag2.bag, msg)''
         """
-        with self._bag_lock:
-            entry_bag, entry = None, None
-            for bag in self._bags:
-                bag_entry = bag.get_entry(t - Duration(nanoseconds=1))
-                if bag_entry and (not entry or bag_entry.timestamp < entry.timestamp):
-                    entry_bag, entry = bag, bag_entry
-
-            return entry_bag, entry
+        return self.get_entry(t - Duration(nanoseconds=1))
 
     def get_entry_after(self, t, topic=None):
         """

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -312,7 +312,7 @@ class BagTimeline(QGraphicsScene):
         Access a bag entry
         :param t: time, ''rclpy.time.Time''
         :param topic: the topic to be accessed, ''str''
-        :return: tuple of (bag, entry) closest less than or equal to t, ''(rosbag2.bag, msg)''
+        :return: tuple of (bag, entry) corresponding to time t and topic, ''(rosbag2.bag, msg)''
         """
         with self._bag_lock:
             entry_bag, entry = None, None
@@ -327,9 +327,16 @@ class BagTimeline(QGraphicsScene):
         """
         Access a bag entry
         :param t: time, ''rclpy.time.Time''
-        :return: tuple of (bag, entry) closest less than but not equal to t, ''(rosbag2.bag, msg)''
+        :return: tuple of (bag, entry) corresponding to time t, ''(rosbag2.bag, msg)''
         """
-        return self.get_entry(t - Duration(nanoseconds=1))
+        with self._bag_lock:
+            entry_bag, entry = None, None
+            for bag in self._bags:
+                bag_entry = bag.get_entry(t - Duration(nanoseconds=1))
+                if bag_entry and (not entry or bag_entry.timestamp < entry.timestamp):
+                    entry_bag, entry = bag, bag_entry
+
+            return entry_bag, entry
 
     def get_entry_after(self, t, topic=None):
         """

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -260,8 +260,7 @@ class Recorder(object):
                     self.rosbag_writer.write(topic, serialize_message(msg), t.nanoseconds)
 
                     # Update the overall duration for this bag based on the message just added
-                    duration_ns = t.nanoseconds - self._bag.start_time.nanoseconds
-                    self._bag.duration = Duration(nanoseconds=duration_ns)
+                    self._bag.duration = t - self._bag.get_earliest_timestamp()
 
                 # Notify listeners that a message has been recorded
                 for listener in self._listeners:

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -258,9 +258,7 @@ class Recorder(object):
                 topic, msg, msg_type_name, t = item
                 with self._bag_lock:
                     self.rosbag_writer.write(topic, serialize_message(msg), t.nanoseconds)
-
-                    # Update the overall duration for this bag based on the message just added
-                    self._bag.duration = t - self._bag.get_earliest_timestamp()
+                    self._bag.set_latest_timestamp(t)
 
                 # Notify listeners that a message has been recorded
                 for listener in self._listeners:

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -136,7 +136,7 @@ class Rosbag2:
             return None
 
         self.reader.set_read_order(rosbag2_py.ReadOrder(reverse=False))
-        self.reader.seek(timestamp.nanoseconds)
+        self.reader.seek(timestamp.nanoseconds + 1)
         return self.read_next() if self.reader.has_next() else None
 
     def get_entries_in_range(self, t_start, t_end, topic=None):

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -36,7 +36,6 @@
 from collections import namedtuple
 import os
 import pathlib
-import sqlite3
 
 from rclpy.clock import Clock, ClockType
 from rclpy.duration import Duration
@@ -48,6 +47,8 @@ from rosidl_runtime_py.utilities import get_message
 import yaml
 
 WRITE_ONLY_MSG = "open for writing only, returning None"
+
+Entry = namedtuple('Entry', ['topic', 'data', 'timestamp'])
 
 
 class Rosbag2:
@@ -73,6 +74,9 @@ class Rosbag2:
                 t_info.topic_metadata.name: t_info.topic_metadata
                 for t_info in self.metadata.topics_with_message_count
             }
+            self.read_order = rosbag2_py.ReadOrder(
+                sort_by=rosbag2_py.ReadOrderSortBy.ReceivedTimestamp,
+                reverse=False)
 
     def size(self):
         """Get the size of the rosbag."""
@@ -120,29 +124,41 @@ class Rosbag2:
         if not self.reader:
             self._logger.warn("get_entry - " + WRITE_ONLY_MSG)
             return None
-        sql_query = 'timestamp<={} ORDER BY messages.timestamp ' \
-                    'DESC LIMIT 1;'.format(timestamp.nanoseconds)
-        result = self._execute_sql_query(sql_query, topic)
-        return result[0] if result else None
+
+        self.reader.set_read_order(rosbag2_py.ReadOrder(reverse=True))
+        self.reader.seek(timestamp.nanoseconds)
+        return self.read_next() if self.reader.has_next() else None
 
     def get_entry_after(self, timestamp, topic=None):
         """Get the next entry after a given timestamp."""
         if not self.reader:
             self._logger.warn("get_entry_after - " + WRITE_ONLY_MSG)
             return None
-        sql_query = 'timestamp>{} ORDER BY messages.timestamp ' \
-                    'LIMIT 1;'.format(timestamp.nanoseconds)
-        result = self._execute_sql_query(sql_query, topic)
-        return result[0] if result else None
+
+        self.reader.set_read_order(rosbag2_py.ReadOrder(reverse=False))
+        self.reader.seek(timestamp.nanoseconds)
+        return self.read_next() if self.reader.has_next() else None
 
     def get_entries_in_range(self, t_start, t_end, topic=None):
         if not self.reader:
             self._logger.warn("get_entries_in_range - " + WRITE_ONLY_MSG)
             return None
-        """Get a list of all of the entries within a given range of timestamps (inclusive)."""
-        sql_query = 'timestamp>={} AND timestamp<={} ' \
-                    'ORDER BY messages.timestamp;'.format(t_start.nanoseconds, t_end.nanoseconds)
-        return self._execute_sql_query(sql_query, topic)
+
+        self.reader.set_read_order(rosbag2_py.ReadOrder(reverse=False))
+        self.reader.set_filter(rosbag2_py.StorageFilter(topics=[topic] if topic else []))
+        self.reader.seek(t_start.nanoseconds)
+        entries = []
+        while self.reader.has_next():
+            next_entry = self.read_next()
+            if next_entry.timestamp <= t_end.nanoseconds:
+                entries.append(next_entry)
+            else:
+                break
+
+        return entries
+
+    def read_next(self):
+        return Entry(*self.reader.read_next())
 
     def deserialize_entry(self, entry):
         """Deserialize a bag entry into its corresponding ROS message."""
@@ -150,20 +166,3 @@ class Rosbag2:
         msg_type = get_message(msg_type_name)
         ros_message = deserialize_message(entry.data, msg_type)
         return (ros_message, msg_type_name, entry.topic)
-
-    def _execute_sql_query(self, sql_query, topic):
-        Entry = namedtuple('Entry', ['topic', 'data', 'timestamp'])
-        base_query = 'SELECT topics.name, data, timestamp FROM messages ' \
-                     'JOIN topics ON messages.topic_id = topics.id WHERE '
-
-        # If there was a topic requested, make sure it is in this bag
-        if topic is not None:
-            if topic not in self.topic_metadata_map:
-                return []
-            base_query += 'topics.name="{}"AND '.format(topic)
-
-        with sqlite3.connect(self.db_name) as db:
-            cursor = db.cursor()
-            entries = cursor.execute(base_query + sql_query).fetchall()
-            cursor.close()
-            return [Entry(*entry) for entry in entries]

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -78,14 +78,10 @@ class Rosbag2:
 
     def get_earliest_timestamp(self):
         """Get the timestamp of the earliest message in the bag."""
-        self._logger.info("GET START")
         return self.metadata.starting_time
 
     def get_latest_timestamp(self):
         """Get the timestamp of the most recent message in the bag."""
-        self._logger.info("GET END")
-        end = self.metadata.starting_time + self.metadata.duration
-        print("ITS A ", end)
         return self.metadata.starting_time + self.metadata.duration
 
     def get_topics(self):
@@ -119,7 +115,7 @@ class Rosbag2:
         if not self.reader:
             self._logger.warn("get_entry - " + WRITE_ONLY_MSG)
             return None
-        self._logger.info("GET ENTRY")
+        self._logger.info(f"get_entry {timestamp}")
         sql_query = 'timestamp<={} ORDER BY messages.timestamp ' \
                     'DESC LIMIT 1;'.format(timestamp.nanoseconds)
         result = self._execute_sql_query(sql_query, topic)
@@ -130,7 +126,7 @@ class Rosbag2:
         if not self.reader:
             self._logger.warn("get_entry_after - " + WRITE_ONLY_MSG)
             return None
-        self._logger.info("GET ENTRY AFTER")
+        self._logger.info(f"get_entry_after {timestamp}")
         sql_query = 'timestamp>{} ORDER BY messages.timestamp ' \
                     'LIMIT 1;'.format(timestamp.nanoseconds)
         result = self._execute_sql_query(sql_query, topic)
@@ -141,7 +137,7 @@ class Rosbag2:
             self._logger.warn("get_entries_in_range - " + WRITE_ONLY_MSG)
             return None
         """Get a list of all of the entries within a given range of timestamps (inclusive)."""
-        self._logger.info("GET ENTRIES IN RANGE")
+        self._logger.info(f"get_entries_in_range {t_start} -> {t_end}")
         sql_query = 'timestamp>={} AND timestamp<={} ' \
                     'ORDER BY messages.timestamp;'.format(t_start.nanoseconds, t_end.nanoseconds)
         return self._execute_sql_query(sql_query, topic)

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -899,6 +899,19 @@ class TimelineFrame(QGraphicsItem):
 
         return len(topic_cache) - topic_cache_len
 
+
+    def cache_message(self, topic, t):
+        """
+        Updates the cache of message timestamps with a specific new message,
+        bypassing any need to read entries from the bag.
+        """
+        if self._start_stamp is None or self._end_stamp is None:
+            return 0
+
+        topic_cache = self.index_cache.setdefault(topic, [])
+        topic_cache.append(bag_helper.to_sec(t))
+
+
     def _find_regions(self, stamps, max_interval):
         """
         Group timestamps into regions connected by timestamps less than max_interval secs apart


### PR DESCRIPTION
Depends on ros2/rosbag2#1082
Depends on https://github.com/ros2/rosbag2/pull/1083
Closes #121

* Use the `rosbag2_py` API to get metadata about a bag being read, instead of parsing `metadata.yaml` directly.
* Use `SequentialReader` API with new ReadOrder feature, to do all message queries, removing `sqlite3` usage 

Removes hardcoded client knowledge, so that `rqt_bag` can open rosbag2 files with any supported storage backend.