### PR TITLE
Changes the use of __slots__ for the field and field type getter

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -435,8 +435,8 @@ class MessageTree(QTreeWidget):
         # Remove the leading underscore for display
         label = name[1:] if name.startswith('_') else name
 
-        if hasattr(obj, '__slots__'):
-            subobjs = [(slot, getattr(obj, slot)) for slot in obj.__slots__]
+        if hasattr(obj, '_fields_and_field_types'):
+            subobjs = [(field_name, getattr(obj, field_name)) for field_name in obj.get_fields_and_field_types().keys()]
         elif type(obj) in [list, tuple]:
             len_obj = len(obj)
             if len_obj == 0:


### PR DESCRIPTION
This PR modifies the use of __slots__ for the appropriate message components name getter. This changes should solve the problems when https://github.com/ros2/rosidl_python/pull/194 is incorporated.