### PR TITLE
[ros2] Use default storage id from rosbag2

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -117,7 +117,7 @@ class BagTimeline(QGraphicsScene):
 
         # Database settings
         self.serialization_format = 'cdr'
-        self.storage_id = 'sqlite3'
+        self.storage_id = rosbag2_py.get_default_storage_id()
 
     def get_context(self):
         """

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -54,6 +54,8 @@ from rosidl_runtime_py.utilities import get_message
 from .qos import gen_subscriber_qos_profile, get_qos_profiles_for_topic, qos_profiles_to_yaml
 from .rosbag2 import Rosbag2
 
+from rosbag2_py import get_default_storage_id
+
 
 class Recorder(object):
 
@@ -97,7 +99,7 @@ class Recorder(object):
         self._message_count = {}  # topic -> int (track number of messages recorded on each topic)
 
         self._serialization_format = 'cdr'
-        self._storage_id = 'sqlite3'
+        self._storage_id = get_default_storage_id()
         self._storage_options = rosbag2_py.StorageOptions(
             uri=filename, storage_id=self._storage_id)
         self._converter_options = rosbag2_py.ConverterOptions(

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -46,6 +46,8 @@ import rosbag2_py
 from rosidl_runtime_py.utilities import get_message
 import yaml
 
+from rosbag2_py import get_default_storage_id
+
 WRITE_ONLY_MSG = "open for writing only, returning None"
 
 Entry = namedtuple('Entry', ['topic', 'data', 'timestamp'])
@@ -54,7 +56,7 @@ Entry = namedtuple('Entry', ['topic', 'data', 'timestamp'])
 class Rosbag2:
 
     def __init__(self, bag_path, recording=False, topics={},
-                 serialization_format='cdr', storage_id='sqlite3'):
+                 serialization_format='cdr', storage_id=get_default_storage_id()):
         self.bag_path = bag_path
         self.reader = None
         self._logger = logging.get_logger('rqt_bag.Rosbag2')


### PR DESCRIPTION
This PR replaces references to `sqlite3` with `rosbag2_py.get_default_storage_id()` so that `rqt_bag` always defaults to the same storage format as `rosbag2`.