### PR TITLE
Add a dependency on pytest to rqt_bag and rqt_bag_plugins.

### DIFF
--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -22,6 +22,8 @@
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -30,5 +30,6 @@ setup(
         'rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     scripts=['scripts/rqt_bag'],
 )

--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -28,6 +28,8 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
     <rqt_bag plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag_plugins/setup.py
+++ b/rqt_bag_plugins/setup.py
@@ -29,4 +29,5 @@ setup(
         'rqt_bag_plugins provides GUI plugins for rqt_bag to display various message types.'
     ),
     license='BSD',
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
While there aren't currently any tests, this sets them up to have pytest tests in the future.