### PR TITLE
Revert "Add a dependency on pytest to rqt_bag and rqt_bag_plugins. (#…

### DIFF
--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -22,8 +22,6 @@
   <exec_depend version_gte="0.2.12">rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 
-  <test_depend>python3-pytest</test_depend>
-
   <export>
     <build_type>ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -30,6 +30,5 @@ setup(
         'rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.'
     ),
     license='BSD',
-    tests_require=['pytest'],
     scripts=['scripts/rqt_bag'],
 )

--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -28,8 +28,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
-  <test_depend>python3-pytest</test_depend>
-
   <export>
     <build_type>ament_python</build_type>
     <rqt_bag plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag_plugins/setup.py
+++ b/rqt_bag_plugins/setup.py
@@ -29,5 +29,4 @@ setup(
         'rqt_bag_plugins provides GUI plugins for rqt_bag to display various message types.'
     ),
     license='BSD',
-    tests_require=['pytest'],
 )


### PR DESCRIPTION
…148)"

This reverts commit f0a47cff483b2d776b672c7b5ebb5a1f2c67bde9.

The main reason to do this is that on Windows Debug, we don't currently have a Debug wheel for PyQt.  Thus these tests always fail on that platform.  While the "correct" solution is to build a Windows Debug PyQt wheel, that is a decidedly difficult undertaking.  Since we don't have tests to speak of in these packages, avoid the problem for now by just going back to what we were doing before, i.e. using unittest for the tests.

This should fix part of the failing Windows Debug nightlies, like https://ci.ros2.org/view/nightly/job/nightly_win_deb/2999/