### PR TITLE
Improved raw view to better handle arrays and time objects

### DIFF
--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -28,8 +28,12 @@
 
 """Defines a raw view: a TopicMessageView that displays the message contents in a tree."""
 
-import codecs
+import array
 import math
+
+from builtin_interfaces.msg import Time as TimeMsg
+
+import numpy
 
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtWidgets import \
@@ -38,6 +42,9 @@ from python_qt_binding.QtWidgets import \
 from rclpy.time import Time
 
 from .topic_message_view import TopicMessageView
+
+MAX_LIST_LEN = 50
+LIST_TAIL_LEN = 10
 
 
 class RawView(TopicMessageView):
@@ -181,13 +188,23 @@ class MessageTree(QTreeWidget):
 
         if hasattr(obj, '__slots__'):
             subobjs = [(slot, getattr(obj, slot)) for slot in obj.__slots__]
-        elif type(obj) in [list, tuple]:
-            len_obj = len(obj)
+        elif type(obj) in (list, tuple, array.array, numpy.ndarray):
+            if type(obj) in (array.array, numpy.ndarray):
+                list_obj = obj.tolist()
+            else:
+                list_obj = obj
+            len_obj = len(list_obj)
+            short_list_obj = list_obj[:MAX_LIST_LEN]
             if len_obj == 0:
                 subobjs = []
             else:
                 w = int(math.ceil(math.log10(len_obj)))
-                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(obj)]
+                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(short_list_obj)]
+                if len_obj > MAX_LIST_LEN:
+                    subobjs.append(('[%s]' % (w * '.',), '{} items total'.format(len_obj)))
+                    for i in range(-LIST_TAIL_LEN, 0):
+                        if len_obj + i >= MAX_LIST_LEN:
+                            subobjs.append(('[%*d]' % (w, len_obj + i), list_obj[i]))
         else:
             subobjs = []
 
@@ -202,9 +219,21 @@ class MessageTree(QTreeWidget):
             else:
                 label += ':  %s' % obj_repr
 
-        elif type(obj) in (str, bool, int, float, complex, Time):
-            # Ignore any binary data
-            obj_repr = codecs.utf_8_decode(str(obj).encode(), 'ignore')[0]
+        elif type(obj) in (str, bool, int, float, complex, Time, TimeMsg, list, tuple,
+                           array.array, numpy.ndarray):
+            if type(obj) is array.array:
+                if obj.typecode == 'B':
+                    obj_repr = obj.tobytes().decode('utf-8', 'ignore')
+                elif obj.typecode == 'u':
+                    obj_repr = ''.join(obj.tolist())
+                else:
+                    obj_repr = '[' + ','.join(map(str, obj.tolist())) + ']'
+            elif type(obj) is Time:
+                obj_repr = '{:.9f}'.format(obj.nanoseconds * 1e-9)
+            elif type(obj) is TimeMsg:
+                obj_repr = '{:.9f}'.format(Time.from_msg(obj).nanoseconds * 1e-9)
+            else:
+                obj_repr = str(obj)
 
             # Truncate long representations
             if len(obj_repr) >= 50:


### PR DESCRIPTION
This PR adds handling of array and time types to raw_view.

It extends #152 and applies the fix from #94.

The exact features this PRs adds are:

1. Add subobjects for arrays. The maximum number of added subobjects is `MAX_LIST_LEN` + `LIST_TAIL_LEN` (50 + 10). If the list is longer, the values between indices 50 and (end-10) are left out. Instead, a placeholder with the total number of items is shown.
2. Add the first 50 characters of the array string representation to the label. `array.array` with `B` and `u` types have string-like handling, other arrays (and numpy arrays) are just printed using `str()` of their elements.
3. For `Time` objects, label is extended to contain the float value of the object.

## Screenshots

### Current behavior

![Snímek obrazovky pořízený 2025-05-07 01-18-02](https://github.com/user-attachments/assets/abe9eb1f-f24e-4b25-b689-80b4afce3de5)

### New behavior

![Snímek obrazovky pořízený 2025-05-07 01-15-58](https://github.com/user-attachments/assets/aa6e7480-3a2e-4177-9c2e-8659c38522ec)
![Snímek obrazovky pořízený 2025-05-07 01-16-55](https://github.com/user-attachments/assets/4b47e944-c045-437d-a598-10fa252a822c)
