### PR TITLE
Improve plot view

### DIFF
--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>python3-cairo</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2</exec_depend>

--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -19,6 +19,7 @@
   <author>Tim Field</author>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>python3-cairo</exec_depend>
   <exec_depend>python3-numpy</exec_depend>

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -60,11 +60,12 @@
 #  doesn't make sense to make it align with the timeline. This could be done
 #  if someone wanted to implement a separate timeline view
 
-import array
 import codecs
 import math
+from numbers import Complex, Number, Real
 import os
 import threading
+from typing import Sequence
 
 from ament_index_python import get_resource
 
@@ -89,6 +90,7 @@ from rqt_plot.data_plot import DataPlot
 
 MAX_LIST_LEN = 50
 LIST_TAIL_LEN = 10
+FLOAT_SECONDS_LABEL = '*float_seconds'
 
 
 class PlotView(MessageView):
@@ -269,10 +271,10 @@ class PlotWidget(QWidget):
                             if field.endswith(']'):
                                 field = field[:-1]
                                 field, _, index = field.rpartition('[')
-                            if type(y_value) in (Time, TimeMsg) and field == '*float_seconds':
+                            if type(y_value) in (Time, TimeMsg) and field == FLOAT_SECONDS_LABEL:
                                 time_val = y_value if type(y_value) is Time \
                                            else Time().from_msg(y_value)
-                                y_value = time_val.nanoseconds * 1e-9
+                                y_value = bag_helper.to_sec(time_val)
                             else:
                                 y_value = getattr(y_value, field)
                             if index:
@@ -451,31 +453,26 @@ class MessageTree(QTreeWidget):
             subobjs = [(field_name, getattr(obj, field_name)) for field_name in field_keys]
             if type(obj) in (Time, TimeMsg):
                 time_obj = obj if type(obj) is Time else Time().from_msg(obj)
-                subobjs.append(('*float_seconds', time_obj.nanoseconds * 1e-9))
-        elif type(obj) in (list, tuple, array.array, numpy.ndarray):
-            if type(obj) in (array.array, numpy.ndarray):
-                list_obj = obj.tolist()
-            else:
-                list_obj = obj
-            len_obj = len(list_obj)
-            short_list_obj = list_obj[:MAX_LIST_LEN]
+                subobjs.append((FLOAT_SECONDS_LABEL, bag_helper.to_sec(time_obj)))
+        elif isinstance(obj, (Sequence, numpy.ndarray)) and not isinstance(obj, str):
+            len_obj = len(obj)
+            short_obj = obj[:MAX_LIST_LEN]
 
             if len_obj == 0:
                 subobjs = []
             else:
                 w = int(math.ceil(math.log10(len_obj)))
-                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(short_list_obj)]
-                if len_obj > MAX_LIST_LEN:
-                    for i in range(-LIST_TAIL_LEN, 0):
-                        if len_obj + i >= MAX_LIST_LEN:
-                            subobjs.append(('[%*d]' % (w, len_obj + i), list_obj[i]))
+                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(short_obj)]
+                tail_start = max(MAX_LIST_LEN, len_obj - LIST_TAIL_LEN)
+                subobjs.extend([('[%*d]' % (w, i + tail_start), subobj)
+                                for (i, subobj) in enumerate(obj[tail_start:])])
         else:
             subobjs = []
 
         plotitem = False
-        if type(obj) in (int, float):
+        if isinstance(obj, Number):
             plotitem = True
-            if isinstance(obj, float):
+            if isinstance(obj, Real):
                 obj_repr = '%.6f' % obj
             else:
                 obj_repr = str(obj)
@@ -485,7 +482,7 @@ class MessageTree(QTreeWidget):
             else:
                 label += ':  %s' % obj_repr
 
-        elif type(obj) in [str, bool, int, float, complex, Time]:
+        elif type(obj) in [str, bool, Complex, Time]:
             # Ignore any binary data
             obj_repr = codecs.utf_8_decode(str(obj).encode(), 'ignore')[0]
 

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -456,13 +456,13 @@ class MessageTree(QTreeWidget):
                 subobjs.append((FLOAT_SECONDS_LABEL, bag_helper.to_sec(time_obj)))
         elif isinstance(obj, (Sequence, numpy.ndarray)) and not isinstance(obj, str):
             len_obj = len(obj)
-            short_obj = obj[:MAX_LIST_LEN]
 
             if len_obj == 0:
                 subobjs = []
             else:
                 w = int(math.ceil(math.log10(len_obj)))
-                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(short_obj)]
+                subobjs = [('[%*d]' % (w, i), subobj)
+                           for (i, subobj) in enumerate(obj[:MAX_LIST_LEN])]
                 tail_start = max(MAX_LIST_LEN, len_obj - LIST_TAIL_LEN)
                 subobjs.extend([('[%*d]' % (w, i + tail_start), subobj)
                                 for (i, subobj) in enumerate(obj[tail_start:])])

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -277,9 +277,13 @@ class PlotWidget(QWidget):
                                 y_value = getattr(y_value, field)
                             if index:
                                 index = int(index)
-                                y_value = y_value[index]
-                        y[path].append(y_value)
-                        x[path].append(bag_helper.to_sec(timestamp - self.start_stamp))
+                                try:
+                                    y_value = y_value[index]
+                                except IndexError:
+                                    y_value = None
+                        if y_value is not None:
+                            y[path].append(y_value)
+                            x[path].append(bag_helper.to_sec(timestamp - self.start_stamp))
 
                 # TODO: incremental plot updates would go here...
                 #       we should probably do incremental updates based on time;

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -60,12 +60,15 @@
 #  doesn't make sense to make it align with the timeline. This could be done
 #  if someone wanted to implement a separate timeline view
 
+import array
 import codecs
 import math
 import os
 import threading
 
 from ament_index_python import get_resource
+
+import numpy
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, qWarning
@@ -81,6 +84,9 @@ from rqt_bag import bag_helper
 from rqt_bag import MessageView
 
 from rqt_plot.data_plot import DataPlot
+
+MAX_LIST_LEN = 50
+LIST_TAIL_LEN = 10
 
 
 class PlotView(MessageView):
@@ -432,18 +438,28 @@ class MessageTree(QTreeWidget):
         if hasattr(obj, '_fields_and_field_types'):
             field_keys = obj.get_fields_and_field_types().keys()
             subobjs = [(field_name, getattr(obj, field_name)) for field_name in field_keys]
-        elif type(obj) in [list, tuple]:
-            len_obj = len(obj)
+        elif type(obj) in (list, tuple, array.array, numpy.ndarray):
+            if type(obj) in (array.array, numpy.ndarray):
+                list_obj = obj.tolist()
+            else:
+                list_obj = obj
+            len_obj = len(list_obj)
+            short_list_obj = list_obj[:MAX_LIST_LEN]
+
             if len_obj == 0:
                 subobjs = []
             else:
                 w = int(math.ceil(math.log10(len_obj)))
-                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(obj)]
+                subobjs = [('[%*d]' % (w, i), subobj) for (i, subobj) in enumerate(short_list_obj)]
+                if len_obj > MAX_LIST_LEN:
+                    for i in range(-LIST_TAIL_LEN, 0):
+                        if len_obj + i >= MAX_LIST_LEN:
+                            subobjs.append(('[%*d]' % (w, len_obj + i), list_obj[i]))
         else:
             subobjs = []
 
         plotitem = False
-        if type(obj) in [int, float]:
+        if type(obj) in (int, float):
             plotitem = True
             if isinstance(obj, float):
                 obj_repr = '%.6f' % obj

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -68,6 +68,8 @@ import threading
 
 from ament_index_python import get_resource
 
+from builtin_interfaces.msg import Time as TimeMsg
+
 import numpy
 
 from python_qt_binding import loadUi
@@ -267,7 +269,12 @@ class PlotWidget(QWidget):
                             if field.endswith(']'):
                                 field = field[:-1]
                                 field, _, index = field.rpartition('[')
-                            y_value = getattr(y_value, field)
+                            if type(y_value) in (Time, TimeMsg) and field == '*float_seconds':
+                                time_val = y_value if type(y_value) is Time \
+                                           else Time().from_msg(y_value)
+                                y_value = time_val.nanoseconds * 1e-9
+                            else:
+                                y_value = getattr(y_value, field)
                             if index:
                                 index = int(index)
                                 y_value = y_value[index]
@@ -438,6 +445,9 @@ class MessageTree(QTreeWidget):
         if hasattr(obj, '_fields_and_field_types'):
             field_keys = obj.get_fields_and_field_types().keys()
             subobjs = [(field_name, getattr(obj, field_name)) for field_name in field_keys]
+            if type(obj) in (Time, TimeMsg):
+                time_obj = obj if type(obj) is Time else Time().from_msg(obj)
+                subobjs.append(('*float_seconds', time_obj.nanoseconds * 1e-9))
         elif type(obj) in (list, tuple, array.array, numpy.ndarray):
             if type(obj) in (array.array, numpy.ndarray):
                 list_obj = obj.tolist()


### PR DESCRIPTION
This PR improves handling of array and time types in plot_view.

This PR adds the following features:

1. It handles `array.array` and `numpy.ndarray` similar to `list` and `tuple`
2. It limits the maximum number of subobjects for list-like items to `MAX_LIST_LEN` + `LIST_TAIL_LEN`. Items on indices between `MAX_LIST_LEN` and `end - LIST_TAIL_LEN` are omitted.
3. If a list-like object has variable size (like `CompressedImage.data`), the user can select an index that is not present in all messages. In such case, the missing data are ignored and nothing is put on the timeline for that particular time.
4. It adds a virtual field `*float_seconds` to time message. This field contains the time value converted to float.

## Screenshots

### Current state
![Snímek obrazovky pořízený 2025-05-07 01-46-47](https://github.com/user-attachments/assets/714c32b9-6a7c-44f7-b7b1-40bde69f7c9c)

### New behavior

![Snímek obrazovky pořízený 2025-05-07 01-43-49](https://github.com/user-attachments/assets/964255d0-ff99-405a-8813-6de45a4b0ec5)
![Snímek obrazovky pořízený 2025-05-07 01-44-00](https://github.com/user-attachments/assets/0caa4482-744c-4e79-8a22-a82782fb6315)
![Snímek obrazovky pořízený 2025-05-07 01-45-00](https://github.com/user-attachments/assets/958a0980-7065-4f55-a302-43dc88eebd1a)

