### PR TITLE
Fixed timeline resolution

### DIFF
--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -1005,11 +1005,11 @@ class TimelineFrame(QGraphicsItem):
 
         if clamp_to_visible:
             if fraction <= 0.0:
-                return int(self._stamp_left)
+                return self._stamp_left
             elif fraction >= 1.0:
-                return int(self._stamp_right)
+                return self._stamp_right
 
-        return int(self._stamp_left + fraction * (self._stamp_right - self._stamp_left))
+        return self._stamp_left + fraction * (self._stamp_right - self._stamp_left)
 
     def map_dx_to_dstamp(self, dx):
         """


### PR DESCRIPTION
Currently, the navigation bar on the timeline has a "resolution" of 1 second for mouse clicks.

The wrong behavior was added in #118.

It makes sense to round to int `map_stamp_to_x` result, but not the result of `map_x_to_stamp`.

Current (wrong) behavior: the timeline cannot be moved by clicking to any timestamp with non-zero fractional seconds. This is best tested on a short bag file (e.g. 30 secs). Also, the start point of the bag file (as reported in the status bar) is in negative time relative to start of bag (e.g. when bag started at 1234567890.25, the beginning of the bag will show relative time -0.75). Also, this has bad influence in timeline thumbnails. Until the bag start is scrolled out of view, no thumbnails appear on any topic.

Fixed behavior: clicking in the timeline moves the cursor exactly where it should be.

I checked all places where the result of `map_x_to_stamp` can be used and I haven't discovered any place which would need to add an explicit `int()`.