### PR TITLE
Fixed image helper and added support for PNG-coded compressedDepth

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -29,11 +29,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import array
-from io import StringIO
+from io import BytesIO
 import sys
 
 from PIL import Image
 from PIL import ImageOps
+from PIL import UnidentifiedImageError
 try:
     import cairo
 except ImportError:
@@ -43,10 +44,18 @@ except ImportError:
 def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
     try:
         if msg_type_name == 'sensor_msgs/msg/CompressedImage':
-            pil_img = Image.open(StringIO(img_msg.data))
-            if pil_img.mode != 'L':
-                pil_img = pil_bgr2rgb(pil_img)
-            pil_mode = 'RGB'
+            try:
+                pil_img = Image.open(BytesIO(img_msg.data))
+            except UnidentifiedImageError:
+                # Try decoding compressedDepth which stores a 12-byte ConfigHeader first
+                pil_img = Image.open(BytesIO(img_msg.data[12:]))
+
+            if pil_img.mode == 'I' and 'compressedDepth' in img_msg.format:
+                pil_mode = 'I;16'
+            else:
+                if pil_img.mode.startswith('BGR'):
+                    pil_img = pil_bgr2rgb(pil_img)
+                pil_mode = 'RGB'
         else:
             pil_mode = 'RGB'
             if img_msg.encoding in ('mono8', '8UC1'):
@@ -89,6 +98,7 @@ def imgmsg_to_pil(img_msg, msg_type_name, rgba=True):
         # 16 bits conversion to 8 bits
         if pil_mode == 'I;16':
             pil_img = pil_img.convert('I').point(lambda i: i * (1. / 256.)).convert('L')
+            pil_img = ImageOps.autocontrast(pil_img)
 
         if pil_img.mode == 'F':
             pil_img = pil_img.point(lambda i: i * (1. / 256.)).convert('L')


### PR DESCRIPTION
This PR fixes the image_helper. I don't really understand how it could be so broken for such a long time in ROS 2 (I mean, did it ever work for CompressedImage?).

This PR takes parts of #68, mostly the switch to `BytesIO` and the conditioning of BGR->RGB conversion.

It also adds support for PNG-coded `compressedDepth` images. The `compressed_depth_transport` has a 12-byte `ConfigHeader` stored at the beginning of the binary data, so if these 12 bytes are ignored, the rest of the binary data is a normal PNG image. RVL-coded depth images are not supported.

I also added autocontrast for `I;16` images because without it, the result is quite unusable. #68 also inverts `F` images (but does not do so for `I+16`, which I see as an inconsistency). I decided to not add this inversion, but if it's desired to be compatible with the latest changes from Noetic, I can add it (but I'd prefer adding it for both `F` and `I;16`).

## Current state

Any attempt to view an image (both on the timeline and in the separate image window) ends with these errors in console:

```
Can't convert image: initial_value must be str or None, not array.array
Disabling renderer on /camera_left/image_color/compressed    
Can't convert image: initial_value must be str or None, not array.array
Disabling renderer on /camera_rear/image_color/compressed          
Can't convert image: initial_value must be str or None, not array.array
Disabling renderer on /camera_right/image_color/compressed         
Can't convert image: initial_value must be str or None, not array.array                                                                                                                                     
Disabling renderer on /luxonis/oak/left/image_raw/compressed
Can't convert image: initial_value must be str or None, not array.array
Disabling renderer on /luxonis/oak/left/image_raw/compressed
```

## New behavior
![Snímek obrazovky pořízený 2025-05-07 02-05-11](https://github.com/user-attachments/assets/ddd27540-c363-4c00-8997-4ded4b2bdb33)


