### PR TITLE
Fixed timeline mouse-click behavior and scrollbars

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -555,6 +555,9 @@ class BagTimeline(QGraphicsScene):
     def translate_timeline_right(self):
         self._timeline_frame.translate_timeline_right()
 
+    def update_size(self):
+        self._timeline_frame.update_size()
+
     # Publishing
     def is_publishing(self, topic):
         return self._player and self._player.is_publishing(topic)

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -436,6 +436,7 @@ class BagWidget(QWidget):
         self._timeline.handle_close()
 
     def update_size(self):
+        self._timeline.update_size()
         self._resizeEvent(QResizeEvent(self.size(), self.size()))
 
     def on_mousewheel(self, event):

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -413,6 +413,9 @@ class TimelineFrame(QGraphicsItem):
         if new_history_bottom != self._history_bottom:
             self._history_bottom = new_history_bottom
 
+    def update_size(self):
+        self._layout()
+
     def _draw_topic_histories(self, painter):
         """
         Draw all topic messages.


### PR DESCRIPTION
When I launch rqt_bag, it shows up on my primary display. However, I cannot click most parts of the timeline to move the caret. There's no reaction at all. Usually, I can only click about 100 px from the left side of the bag view. Also, there is no vertical scrollbar even if it should be there.

I tried printing `mousePressEvent` in `TimelineFrame` and it is indeed not called on some parts of the bag view.

Then I went down the rabbit hole trying to find out where does the event get lost. I'm pretty confident that the culprit is in wrong initialization of the internal index held by `BagTimeline(QGraphicsScene)`. When this index is wrong, the hit test in `QGraphicsScene` will not succeed for the `TimelineFrame` item and it will not receive the event. My guess is that the index is computed before the timeline object is resized.

One way to reset the index is to resize the window. If I resize it (via the OS GUI buttons), the problem gets fixed and I can click anywhere (well, up to #175) and the scrollbar appears. However, this is not very convenient

Another way to reset the index is to trigger a resize event programatically. That's basically what #63 does. So I ported a similar fix into ROS 2.

---

First, I thought this might be an issue with my multi-monitor setup. However, now I figured it behaves the same just with the laptop on my lap, so no external displays... Anyways, if it helps, I have a multi-monitor setup where the primary screen is not the top-left-most one:

```
output DisplayPort-7
mode 1920x1200
pos 0x0
rate 59.95
rotate left
output DisplayPort-4
mode 1920x1200
pos 1200x379
primary
rate 59.95
output eDP
mode 1920x1080
pos 1200x1579
rate 60.00
```

So, `DisplayPort-7` is the top-left-most one, and it is rotated, so it is 1200x1920. `DisplayPort-4` is the primary display and its top left corner lies on coordinates `1200x379` of the global space.