### PR TITLE
plot_view: Fixed display of initial message

### DIFF
--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -170,6 +170,8 @@ class Rosbag2:
             else:
                 break
 
+        # No filter
+        self.reader.reset_filter()
         return entries
 
     def read_next(self):

--- a/rqt_bag/src/rqt_bag/rosbag2.py
+++ b/rqt_bag/src/rqt_bag/rosbag2.py
@@ -143,7 +143,16 @@ class Rosbag2:
 
         self.reader.set_read_order(rosbag2_py.ReadOrder(reverse=False))
         self.reader.seek(timestamp.nanoseconds + 1)
-        return self.read_next() if self.reader.has_next() else None
+
+        # Set filter for topic of string type
+        if topic:
+            storage_filter = StorageFilter(topics=[topic])
+            self.reader.set_filter(storage_filter)
+
+        result = self.read_next() if self.reader.has_next() else None
+        # No filter
+        self.reader.reset_filter()
+        return result
 
     def get_entries_in_range(self, t_start, t_end, topic=None):
         if not self.reader:

--- a/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/plot_view.py
@@ -169,11 +169,15 @@ class PlotWidget(QWidget):
             bag, entry = self.timeline.get_entry(start_time, topic)
             if bag is None:
                 bag, entry = self.timeline.get_entry_after(start_time, topic)
-                start_time = Time(nanoseconds=entry.timestamp)
+                if entry is not None:
+                    start_time = Time(nanoseconds=entry.timestamp)
+                else:
+                    break
 
         self.bag = bag
-        (ros_message, msg_type) = self.bag.deserialize_entry(entry)
-        self.message_tree.set_message(ros_message, msg_type)
+        if entry is not None:
+            (ros_message, msg_type) = self.bag.deserialize_entry(entry)
+            self.message_tree.set_message(ros_message, msg_type)
 
         # state used by threaded resampling
         self.resampling_active = False


### PR DESCRIPTION
In the initial state (with playhead on the very beginning), displaying plot view of any topic resulted in displaying the very first message in bag (which is usually tf_static or some other latched topics).

I figured the reason is that `get_entry_after()` did not implement limitation by a topic (although it offered this limitation in its API).

This PR fixes the implementation of `get_entry_after()`.

I also found out `self.reader.reset_filter()` is missing after `get_entries_in_range()`, so I also added that.