### PR TITLE
fix setuptools deprecations

### DIFF
--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -22,7 +22,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -30,6 +29,10 @@ setup(
         'rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test' : [
+            'pytest'
+        ]
+    },
     scripts=['scripts/rqt_bag'],
 )

--- a/rqt_bag/setup.py
+++ b/rqt_bag/setup.py
@@ -31,8 +31,8 @@ setup(
     license='BSD',
     extras_require={
         'test' : [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
     scripts=['scripts/rqt_bag'],
 )

--- a/rqt_bag_plugins/setup.py
+++ b/rqt_bag_plugins/setup.py
@@ -30,7 +30,7 @@ setup(
     license='BSD',
         extras_require={
         'test' : [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
 )

--- a/rqt_bag_plugins/setup.py
+++ b/rqt_bag_plugins/setup.py
@@ -21,7 +21,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -29,5 +28,9 @@ setup(
         'rqt_bag_plugins provides GUI plugins for rqt_bag to display various message types.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+        extras_require={
+        'test' : [
+            'pytest'
+        ]
+    },
 )


### PR DESCRIPTION
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: BSD License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************