### PR TITLE
Use scoped PyQt6 enums instead of removed flat aliases

### DIFF
--- a/rqt_bag/src/rqt_bag/message_listener_thread.py
+++ b/rqt_bag/src/rqt_bag/message_listener_thread.py
@@ -35,7 +35,7 @@ from python_qt_binding.QtCore import qWarning
 class ListenerEvent(QEvent):
 
     def __init__(self, data):
-        super().__init__(QEvent.User)
+        super().__init__(QEvent.Type.User)
         self.data = data
 
 

--- a/rqt_bag/src/rqt_bag/plugins/raw_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/raw_view.py
@@ -90,10 +90,10 @@ class MessageTree(QTreeWidget):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setHeaderHidden(False)
         self.setHeaderLabel('')
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self._msg = None
 
         self._expanded_paths = None

--- a/rqt_bag/src/rqt_bag/timeline_menu.py
+++ b/rqt_bag/src/rqt_bag/timeline_menu.py
@@ -68,7 +68,7 @@ class TopicPopupWidget(QWidget):
             context.add_widget(self)
             # make the dock widget closable, even if it normally isn't
             dock_features = self.parent().features()
-            dock_features |= QDockWidget.DockWidgetClosable
+            dock_features |= QDockWidget.DockWidgetFeature.DockWidgetClosable
             self.parent().setFeatures(dock_features)
 
             # remove old listener


### PR DESCRIPTION
## Summary

PyQt6 removed the flat enum aliases PyQt5 kept for backwards compatibility (e.g. `QEvent.User`), requiring the fully scoped form instead (e.g. `QEvent.Type.User`). Running `rqt_bag` against PyQt6 bindings currently raises `AttributeError` in several UI code paths:

- `QEvent.User` → crashes constructing `ListenerEvent`, breaking `MessageListenerThread` (spams "Error notifying listener" and busy-loops the timeline repaint if hit during timeline load)
- `QDockWidget.DockWidgetClosable` → crashes right-clicking a topic and choosing a message view from the popup menu
- `QSizePolicy.Expanding` / `QAbstractItemView.ExtendedSelection` → crashes opening the Raw message view specifically

- I confirmed each replacement resolves correctly against the real PyQt6 classes (`QEvent.Type.User`, `QDockWidget.DockWidgetFeature.DockWidgetClosable`, `QSizePolicy.Policy.Expanding`, `QAbstractItemView.SelectionMode.ExtendedSelection`).
- I also swept every `ClassName.attr` access in both `rqt_bag` and `rqt_bag_plugins` by dynamically checking it against the live PyQt6-backed class (rather than a manual grep), to confirm these four are the only remaining flat-enum references in the whole package.

## Test plan

- [x] Verified each of the four fixed enum paths resolves against the installed PyQt6 6.10 bindings
- [x] Ran `flake8` on the three changed files — no new warnings introduced on the changed lines
- [x] Reproduced all four crashes against an unpatched checkout and confirmed each is resolved after the fix (loading a bag and triggering the timeline repaint, right-clicking a topic to open a message view, and opening the Raw view)